### PR TITLE
Fix markdown rendering in pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 [![Build Status](https://travis-ci.org/xbmc/addon-check.svg?branch=master)](https://travis-ci.org/xbmc/addon-check)
+[![PyPI version](https://badge.fury.io/py/kodi-addon-checker.svg)](https://badge.fury.io/py/kodi-addon-checker)
 
 # Kodi Addon checker
 
 This tool checks the Kodi repo for best practices and creates problem and warning reports
 
 ## Features
+
 - Checks if all images are valid images
 
 - Checks if all xml files are valid
@@ -25,42 +27,11 @@ This tool checks the Kodi repo for best practices and creates problem and warnin
 
 ## Installation
 
-Open Terminal in addon-check folder and execute the following command
-
-### Unix
-```
-sudo -H python setup.py install
-```
-## Windows
-```
-py setup.py install
+```bash
+pip install kodi-addon-checker
 ```
 
 ## How to use
 
-1. Open Terminal in addon-repo
-
-2. Execute kodi-addon-checker
-
-### Unix
-```
-kodi-addon-checker
-```
-
-### Windows
-```
-py -m kodi_addon_checker
-```
-
-Above command will run kodi-addon-checker in current working directory
-
-## Uninstall
-### Unix
-```
-pip unistall kodi-addon-checker
-```
-
-### Windows
-```
-py -m pip uninstall kodi-addon-checker
-```
+1. Open Terminal in add-on repository directory
+2. Execute `kodi-addon-checker`

--- a/setup.py
+++ b/setup.py
@@ -10,19 +10,22 @@ REQUIRES = [
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(_ROOT, 'README.md')) as f:
-    LONG_DESCRIPTION = '\n' + f.read()
+    LONG_DESCRIPTION = f.read()
 
 setuptools.setup(
     name="kodi-addon-checker",
     version="0.0.1",
     description="Automatic checks for new repository submissions.",
     long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
     author="Team Kodi",
     url="https://github.com/xbmc/addon-check",
     download_url="https://github.com/xbmc/addon-check/archive/master.zip",
     packages=setuptools.find_packages(),
     install_requires=REQUIRES,
-    entry_points={'console_scripts': ['kodi-addon-checker = kodi_addon_checker.__main__:main']},
+    setup_requires=['setuptools>=38.6.0'],
+    entry_points={'console_scripts': [
+        'kodi-addon-checker = kodi_addon_checker.__main__:main']},
     keywords='kodi add-on add-on_checker',
     classifiers=[
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
@Razzeee,
This PR fixes markdown rendering problem in https://pypi.org/project/kodi-addon-checker/
Though the new PyPi Warehouse supports markdown description, you have to use the following commands in the exact order to get expected formatting.

Prerequisite: Upgrade `setuptools` and `twine`
```
sudo pip3 install -U setuptools
sudo pip3 install -U twine
```
Command:
```
python3 setup.py sdist bdist_wheel
# Upload *.tar.gz first
twine upload pypitest dist/*.tar.gz
# Upload *.whl at last
twine upload dist/*.whl
```

Note: This feature is tested on my [personal project](https://test.pypi.org/project/safeeyes/).
I haven't upgraded the version in `setup.py` since this is a minor issue and not necessary to release a new version for this fix.

Also note that a new badge [![PyPI version](https://badge.fury.io/py/kodi-addon-checker.svg)](https://badge.fury.io/py/kodi-addon-checker) to indicate package version is added to the README file.