### PR TITLE
Support multiple repos and add-ons through cmd args

### DIFF
--- a/kodi_addon_checker/__main__.py
+++ b/kodi_addon_checker/__main__.py
@@ -61,9 +61,17 @@ def main():
                 repo_report = check_repo(repo_path, config)
                 report.add(repo_report)
     else:
-        # Treat current directory as repo
-        config = Config(current_dir, args)
-        report = check_repo(current_dir, config)
+        if os.path.isfile(os.path.join(current_dir, "addon.xml")):
+            # Current directory is an add-on
+            report = Report(current_dir)
+            report.add(Record(INFORMATION, "Checking add-on %s" % current_dir))
+            config = Config(None, args)
+            addon_report = check_addon.start(os.path.abspath(current_dir), config)
+            report.add(addon_report)
+        else:
+            # Treat current directory as repo
+            config = Config(current_dir, args)
+            report = check_repo(current_dir, config)
 
     if report.problem_count > 0:
         report.add(Record(PROBLEM, "We found %s problems and %s warnings, please check the logfile." %

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -60,6 +60,7 @@ def _find_in_file(path, search_terms, whitelisted_file_types):
 def start(addon_path, config=None):
     addon_id = os.path.basename(os.path.normpath(addon_path))
     addon_report = Report(addon_id)
+    addon_report.add(Record(INFORMATION, "Checking add-on %s" % addon_id))
 
     global REL_PATH
     # Extract common path from addon paths

--- a/kodi_addon_checker/check_repo.py
+++ b/kodi_addon_checker/check_repo.py
@@ -1,18 +1,14 @@
 import os
 
 import kodi_addon_checker.check_addon as check_addon
-from kodi_addon_checker.record import INFORMATION, Record, PROBLEM, WARNING
+from kodi_addon_checker.record import INFORMATION, Record
 from kodi_addon_checker.report import Report
-from kodi_addon_checker.reporter import ReportManager
 
 
-def check_repo(config, repo_path, parameters):
+def check_repo(repo_path, config):
     repo_report = Report(repo_path)
     repo_report.add(Record(INFORMATION, "Checking repository %s" % repo_path))
-    if len(parameters) == 0:
-        toplevel_folders = sorted(next(os.walk(repo_path))[1])
-    else:
-        toplevel_folders = sorted(parameters)
+    toplevel_folders = sorted(next(os.walk(repo_path))[1])
 
     for addon_folder in toplevel_folders:
         if addon_folder[0] != '.':
@@ -21,11 +17,4 @@ def check_repo(config, repo_path, parameters):
             addon_report = check_addon.start(addon_path, config)
             repo_report.add(addon_report)
 
-    if repo_report.problem_count > 0:
-        repo_report.add(Record(PROBLEM, "We found %s problems and %s warnings, please check the logfile." %
-                               (repo_report.problem_count, repo_report.warning_count)))
-    elif repo_report.warning_count > 0:
-        repo_report.add(Record(WARNING, "We found %s problems and %s warnings, please check the logfile." %
-                               (repo_report.problem_count, repo_report.warning_count)))
-
-    ReportManager.report(repo_report)
+    return repo_report

--- a/kodi_addon_checker/check_repo.py
+++ b/kodi_addon_checker/check_repo.py
@@ -12,7 +12,6 @@ def check_repo(repo_path, config):
 
     for addon_folder in toplevel_folders:
         if addon_folder[0] != '.':
-            repo_report.add(Record(INFORMATION, "Checking add-on %s" % addon_folder))
             addon_path = os.path.join(repo_path, addon_folder)
             addon_report = check_addon.start(addon_path, config)
             repo_report.add(addon_report)

--- a/kodi_addon_checker/config.py
+++ b/kodi_addon_checker/config.py
@@ -16,6 +16,8 @@ class Config(object):
         self._load_config(repo_path)
 
     def _load_config(self, repo_path):
+        if repo_path is None:
+            return
         config_path = os.path.join(repo_path, '.tests-config.json')
         if os.path.isfile(config_path):
             with open(config_path) as json_data:

--- a/kodi_addon_checker/config.py
+++ b/kodi_addon_checker/config.py
@@ -7,6 +7,11 @@ from kodi_addon_checker.reporter import ReportManager
 
 class Config(object):
     def __init__(self, repo_path, cmd_args=None):
+        """
+        Create Config object using .tests-config.json and command line arguments.
+        :param repo_path: the repo path which contains .tests-config.json.
+        :param cmd_args: argparse object
+        """
         self.configs = {} if cmd_args is None else vars(cmd_args)
         self._load_config(repo_path)
 


### PR DESCRIPTION
@Razzeee 
This PR supports multiple add-ons and/or repositories to be passed as command line argument. If none is passed, treat current directory as a repo.

For repositories their respective `.tests-config.json` is used. For add-ons, if there is a `tests-config.json` in the current directory, that will be used.

Tested using two repos (krypton and jarvis) using different `.tests-config.json` settings.

Please note that the command line argument is renamed from `add-on` to `dir`. If you have a better name, please let me know.

Thanks