### PR TITLE
Support multiple repos and add-ons through cmd args

### DIFF
--- a/kodi_addon_checker/__main__.py
+++ b/kodi_addon_checker/__main__.py
@@ -1,9 +1,13 @@
 import argparse
 import os
 
+from kodi_addon_checker import check_addon
 from kodi_addon_checker.check_repo import check_repo
 from kodi_addon_checker.common import load_plugins
 from kodi_addon_checker.config import ConfigManager, Config
+from kodi_addon_checker.record import Record, PROBLEM, WARNING, INFORMATION
+from kodi_addon_checker.report import Report
+from kodi_addon_checker.reporter import ReportManager
 
 
 def dir_type(dir_path):
@@ -21,10 +25,23 @@ def dir_type(dir_path):
     if not os.path.isdir(dir_path):
         raise argparse.ArgumentTypeError(
             "Add-on directory %s does not exist" % dir_path)
-    elif not os.path.isfile(os.path.join(dir_path, "addon.xml")):
-        raise argparse.ArgumentTypeError(
-            "%s does not contain addon.xml" % dir_path)
     return os.path.abspath(dir_path)
+
+
+def check_artifact(artifact_path, args):
+    """
+    Check given artifact and return its report. The artifact can be either an add-on or a repository.
+    :param artifact_path: the path of add-on or repo
+    :param args: argparse object
+    :return: report
+    """
+    artifact_path = os.path.abspath(artifact_path)
+    config = Config(artifact_path, args)
+    ConfigManager.process_config(config)
+    if os.path.isfile(os.path.join(artifact_path, "addon.xml")):
+        return check_addon.start(artifact_path, config)
+    else:
+        return check_repo(artifact_path, config)
 
 
 def main():
@@ -39,15 +56,28 @@ def main():
                                      the current directory.")
     parser.add_argument("--version", action="version",
                         version="%(prog)s 0.0.1")
-    parser.add_argument("add_on", metavar="add-on", type=dir_type, nargs="*",
-                        help="optional add-on directories")
+    parser.add_argument("dir", type=dir_type, nargs="*", help="optional add-on or repo directories")
     ConfigManager.fill_cmd_args(parser)
     args = parser.parse_args()
 
-    repo_path = os.path.abspath(os.getcwd())
-    config = Config(repo_path, args)
-    ConfigManager.process_config(config)
-    check_repo(config, repo_path, args.add_on)
+    if args.dir:
+        # Following report is a wrapper for all sub reports
+        report = Report("")
+        for directory in args.dir:
+            report.add(check_artifact(directory, args))
+    else:
+        report = check_artifact(os.getcwd(), args)
+
+    if report.problem_count > 0:
+        report.add(Record(PROBLEM, "We found %s problems and %s warnings, please check the logfile." %
+                          (report.problem_count, report.warning_count)))
+    elif report.warning_count > 0:
+        report.add(Record(WARNING, "We found %s problems and %s warnings, please check the logfile." %
+                          (report.problem_count, report.warning_count)))
+    else:
+        report.add(Record(INFORMATION, "We found no problems and no warnings, please enjoy your day."))
+
+    ReportManager.report(report)
 
 
 if __name__ == "__main__":

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -60,6 +60,7 @@ def _find_in_file(path, search_terms, whitelisted_file_types):
 def start(addon_path, config=None):
     addon_id = os.path.basename(os.path.normpath(addon_path))
     addon_report = Report(addon_id)
+    addon_report.add(Record(INFORMATION, "Checking add-on %s" % addon_id))
 
     global REL_PATH
     # Extract common path from addon paths

--- a/kodi_addon_checker/check_repo.py
+++ b/kodi_addon_checker/check_repo.py
@@ -1,33 +1,19 @@
 import os
 
 import kodi_addon_checker.check_addon as check_addon
-from kodi_addon_checker.record import INFORMATION, Record, PROBLEM, WARNING
+from kodi_addon_checker.record import INFORMATION, Record
 from kodi_addon_checker.report import Report
-from kodi_addon_checker.reporter import ReportManager
 
 
-def check_repo(config, repo_path, parameters):
+def check_repo(repo_path, config):
     repo_report = Report(repo_path)
     repo_report.add(Record(INFORMATION, "Checking repository %s" % repo_path))
-    if len(parameters) == 0:
-        toplevel_folders = sorted(next(os.walk(repo_path))[1])
-    else:
-        toplevel_folders = sorted(parameters)
+    toplevel_folders = sorted(next(os.walk(repo_path))[1])
 
     for addon_folder in toplevel_folders:
         if addon_folder[0] != '.':
-            repo_report.add(Record(INFORMATION, "Checking add-on %s" % addon_folder))
             addon_path = os.path.join(repo_path, addon_folder)
             addon_report = check_addon.start(addon_path, config)
             repo_report.add(addon_report)
 
-    if repo_report.problem_count > 0:
-        repo_report.add(Record(PROBLEM, "We found %s problems and %s warnings, please check the logfile." %
-                               (repo_report.problem_count, repo_report.warning_count)))
-    elif repo_report.warning_count > 0:
-        repo_report.add(Record(WARNING, "We found %s problems and %s warnings, please check the logfile." %
-                               (repo_report.problem_count, repo_report.warning_count)))
-    else:
-        repo_report.add(Record(INFORMATION, "We found no problems and no warnings, please enjoy your day."))
-
-    ReportManager.report(repo_report)
+    return repo_report

--- a/kodi_addon_checker/config.py
+++ b/kodi_addon_checker/config.py
@@ -7,10 +7,17 @@ from kodi_addon_checker.reporter import ReportManager
 
 class Config(object):
     def __init__(self, repo_path, cmd_args=None):
+        """
+        Create Config object using .tests-config.json and command line arguments.
+        :param repo_path: the repo path which contains .tests-config.json.
+        :param cmd_args: argparse object
+        """
         self.configs = {} if cmd_args is None else vars(cmd_args)
         self._load_config(repo_path)
 
     def _load_config(self, repo_path):
+        if repo_path is None:
+            return
         config_path = os.path.join(repo_path, '.tests-config.json')
         if os.path.isfile(config_path):
             with open(config_path) as json_data:


### PR DESCRIPTION
This PR is a cleaner version of #66.
It allows multiple repositories and add-ons to be passed as command line arguments. After merging this PR `kodi-addon-checker` and `kodi-addon-checker .` are identical.
You can also execute `kodi-addon-checker` from an add-on folder to check that add-on.