### PR TITLE
Add check for complexity of entry point files

### DIFF
--- a/.travis-addon.yml.example
+++ b/.travis-addon.yml.example
@@ -3,12 +3,12 @@ python:
   - "3.6"
 
 install:
-  - pip install Pillow requests
+  - pip install Pillow requests radon
 
 before_install:
   - git submodule update --init --recursive --remote
 
 # command to run our tests
-script: 
-  - cd .tests 
+script:
+  - cd .tests
   - python check_addon.py

--- a/.travis-repo.yml.example
+++ b/.travis-repo.yml.example
@@ -3,14 +3,14 @@ python:
   - "3.6"
 
 install:
-  - pip install Pillow requests
+  - pip install Pillow requests radon
 
 before_install:
   - git submodule update --init --recursive --remote
 
 # command to run our tests
-script: 
-  - cd .tests 
+script:
+  - cd .tests
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then python check_repo.py; fi'
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then python check_repo.py $(git diff --diff-filter=d --name-only HEAD~ | grep / | cut -d / -f1 | sort | uniq); fi'
 

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import re
 import xml.etree.ElementTree
+from radon.raw import analyze
 
 from PIL import Image
 
@@ -79,7 +80,6 @@ def start(addon_path, config=None):
             _check_artwork(addon_report, addon_path, addon_xml, file_index)
 
             max_entrypoint_line_count = config.configs.get("max_entrypoint_line_count", 10)
-            print(max_entrypoint_line_count)
             _check_complex_addon_entrypoint(addon_report, addon_path, max_entrypoint_line_count)
 
             if config.is_enabled("check_license_file_exists"):
@@ -329,20 +329,7 @@ def _check_complex_addon_entrypoint(report: Report, addon_path, max_entrypoint_l
 
 
 def number_of_lines(filepath):
-    lineno = 0
-    skip = False
+    with open(filepath, 'r') as file:
+        data = file.read()
 
-    with open(filepath) as fp:
-
-        for line in fp:
-            line = line.strip()
-
-            if line:
-                if line.startswith('#'):
-                    continue
-                if line.startswith('"""'):
-                    skip = not skip
-                    continue
-                if not skip:
-                    lineno += 1
-    return lineno
+    return(analyze(data).lloc)

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -332,4 +332,4 @@ def number_of_lines(filepath):
     with open(filepath, 'r') as file:
         data = file.read()
 
-    return(analyze(data).lloc)
+    return (analyze(data).lloc)

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -322,8 +322,12 @@ def _check_complex_addon_entrypoint(report: Report, addon_path, max_entrypoint_l
             if not os.path.isdir(filepath):
 
                 if os.path.exists(filepath):
-                    if number_of_lines(filepath) > max_entrypoint_line_count:
-                        report.add(Record(WARNING, "Entry point for the addon is complex. please check %s" % library))
+                    lineno = number_of_lines(filepath)
+                    if lineno >= max_entrypoint_line_count:
+                        report.add(Record(WARNING,
+                                          "Complex entry point. Check: %s | Counted lines: %d | Lines allowed: %d"
+                                          % (library, lineno, max_entrypoint_line_count)))
+
                 else:
                     report.add(Record(PROBLEM, "%s Entry point does not exists" % library))
 


### PR DESCRIPTION
Fixes #68 

I have taken an example `.tests-config.json`

```json
{
    "check_legacy_language_path": false,
    "check_legacy_strings_xml": true,
    "check_license_file_exists": true,
    "comment_on_pull": false,
    "check_dependencies": true,
    "check_complex_files": true,
    "max_line_count": 50,
}
```
Here function name is `check_complex_files` that gets all the extensions from the addon.xml and performs the check and `max_line_count` stores maximum number of lines allowed that will not raise any 
warning.

@enen92 Please let me know if any changes are required.