### PR TITLE
Use libversion instead of LooseVersion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
 
 # command to install dependencies
 install:
-  - pip install pytest Pillow pycodestyle
+  - pip install pytest Pillow pycodestyle libversion
 # command to run tests
 script:
   - py.test -v

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import re
 from radon.raw import analyze
-from distutils.version import LooseVersion
+from libversion import Version
 import xml.etree.ElementTree as ET
 import requests
 
@@ -381,6 +381,6 @@ def _check_dependencies(report: Report, addon_path, repo_addons):
         else:
             available_version = repo_addons[required_addon]
 
-            if LooseVersion(available_version) < LooseVersion(required_version) and (required_addon not in ignore):
+            if Version(available_version) < Version(required_version) and (required_addon not in ignore):
                 report.add(Record(PROBLEM, "Version mismatch for addon %s. Required: %s, Available: %s "
                                   % (required_addon, required_version, available_version)))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ import setuptools
 REQUIRES = [
     'Pillow',
     'requests',
-    'radon'
+    'radon',
+    'libversion'
 ]
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Travis is failing at the moment when we try to run it against our repos. https://travis-ci.org/xbmc/repo-plugins/builds/385427172
And LooseVersion seems to be an internal interface in a deprecated module.

So this is a try to get around that.
