### PR TITLE
Create a logger for debugging

### DIFF
--- a/kodi_addon_checker/__main__.py
+++ b/kodi_addon_checker/__main__.py
@@ -1,5 +1,7 @@
 import argparse
 import os
+import logging
+from kodi_addon_checker import logger
 from kodi_addon_checker import check_addon
 from kodi_addon_checker.check_repo import check_repo
 from kodi_addon_checker.common import load_plugins
@@ -64,9 +66,11 @@ def main():
     parser.add_argument("dir", type=dir_type, nargs="*", help="optional add-on or repo directories")
     parser.add_argument("--branch", choices=choice, required=True,
                         help="Target branch name where the checker will resolve dependencies")
-
     ConfigManager.fill_cmd_args(parser)
     args = parser.parse_args()
+
+    log_file_name = os.path.join(os.getcwd(), "kodi-addon-checker.log")
+    logger.Logger.create_logger(log_file_name, __package__)
 
     if args.dir:
         # Following report is a wrapper for all sub reports

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -6,7 +6,8 @@ from radon.raw import analyze
 from distutils.version import LooseVersion
 import xml.etree.ElementTree as ET
 import requests
-
+import logging
+from kodi_addon_checker import logger
 from PIL import Image
 
 from kodi_addon_checker.common import has_transparency
@@ -61,6 +62,7 @@ def _find_in_file(path, search_terms, whitelisted_file_types):
 
 
 def start(addon_path, repo_addons, config=None):
+    logger = logging.getLogger(__name__)
     addon_id = os.path.basename(os.path.normpath(addon_path))
     addon_report = Report(addon_id)
     addon_report.add(Record(INFORMATION, "Checking add-on %s" % addon_id))

--- a/kodi_addon_checker/logger.py
+++ b/kodi_addon_checker/logger.py
@@ -1,0 +1,22 @@
+import logging
+import logging.handlers
+
+
+class Logger:
+
+    @staticmethod
+    def create_logger(debug_filename, logger_name):
+
+        logger = logging.getLogger(logger_name)
+        logger.setLevel(logging.DEBUG)
+        logger.propagate = False
+        formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s:%(name)s:%(funcName)s: %(message)s',
+                                      datefmt='%Y-%m-%d %H:%M:%S')
+
+        # DEBUG log to 'kodi-addon-checker.log'
+        debug_log_handler = logging.handlers.RotatingFileHandler(debug_filename, encoding='utf-8', mode="w")
+        debug_log_handler.setLevel(logging.DEBUG)
+        debug_log_handler.setFormatter(formatter)
+        logger.addHandler(debug_log_handler)
+
+        return logger


### PR DESCRIPTION
This will help us to debug without messing up the Travis-CI logs. It takes an argument `--log_file` which will be the `path of the log file`. If this argument is not given then by default log file will be created in the current working directory. The name of the log file is `kodi-addon-checker.log`.

The output in the log file will look like:
```
2018-05-31 14:16:38 INFO:kodi_addon_checker.check_addon:start: Hello logging
```
**Note**
Right now there is no logging set in any of the file. But we'll be able to use this logger in future.