### PR TITLE
use requirements.txt file for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
 
 # command to install dependencies
 install:
-  - pip install pytest Pillow pycodestyle
+  - pip install -r requirements.txt
 # command to run tests
 script:
   - py.test -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pillow
+requests
+radon

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,8 @@ import os
 import setuptools
 
 
-REQUIRES = [
-    'Pillow',
-    'requests',
-    'radon'
-]
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -23,7 +20,7 @@ setuptools.setup(
     url="https://github.com/xbmc/addon-check",
     download_url="https://github.com/xbmc/addon-check/archive/master.zip",
     packages=setuptools.find_packages(exclude=['script.test', 'tests*']),
-    install_requires=REQUIRES,
+    install_requires=requirements,
     setup_requires=['setuptools>=38.6.0'],
     entry_points={'console_scripts': [
         'kodi-addon-checker = kodi_addon_checker.__main__:main']},


### PR DESCRIPTION
We are planning to use pipenv for maintaining dependencies but until then we'll be using requirements.txt file.
.travis.yml is updated for installing all the requirements from requirements.txt file