### PR TITLE
Check complex entry point for xml file

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -347,11 +347,12 @@ def _check_complex_addon_entrypoint(report: Report, addon_path, parsed_xml, max_
             filepath = os.path.join(addon_path, library)
 
             if not os.path.isdir(filepath):
+                name, ext = os.path.splitext(filepath)
 
                 if os.path.exists(filepath):
-                    number_of_lines(report, filepath, library,
-                                    max_entrypoint_line_count)
-
+                    if ext == '.py':
+                        number_of_lines(report, filepath, library,
+                                        max_entrypoint_line_count)
                 else:
                     report.add(
                         Record(PROBLEM, "%s Entry point does not exists" % library))


### PR DESCRIPTION
Fix #82 
I have created a new function for counting the lines of `.xml` file.
Now I have added a check that if extension of a file is `.xml` then it will be passed to the new functions i.e `number_of_line_for_xml` for counting the line.
Ony files with `.py` extension will be passed to radon for parsing.

**Note** 
I was not sure what should be the max_entry_point for xml file so I used the default one. Please let me know if we want to use another variable for it. Also should it be fixed value or should we pass it from config ? 