### PR TITLE
Move all_repo_addons function out of __main__.py

### DIFF
--- a/kodi_addon_checker/__main__.py
+++ b/kodi_addon_checker/__main__.py
@@ -10,19 +10,6 @@ from kodi_addon_checker.record import Record, PROBLEM, WARNING, INFORMATION
 from kodi_addon_checker.report import Report
 from kodi_addon_checker.reporter import ReportManager
 
-ROOT_URL = "http://mirrors.kodi.tv/addons/{branch}/addons.xml.gz"
-
-
-def _all_repo_addons():
-    branches = ['gotham', 'helix', 'isengard', 'jarvis', 'krypton', 'leia']
-    repo_addons = {}
-
-    for branch in branches:
-        branch_url = ROOT_URL.format(branch=branch)
-        repo_addons[branch] = check_addon._get_addons(branch_url)
-
-    return repo_addons
-
 
 def dir_type(dir_path):
     """ArgParse callable to validate positional add-on arguments
@@ -51,7 +38,7 @@ def check_artifact(artifact_path, args, branch_name):
     """
     logger = logging.getLogger(__package__)
     logger.info("Downloading all repo addon list")
-    all_repo_addons = _all_repo_addons()
+    all_repo_addons = check_addon.all_repo_addons()
     logger.info("Download completed")
     artifact_path = os.path.abspath(artifact_path)
     config = Config(artifact_path, args)

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -18,6 +18,7 @@ from kodi_addon_checker.record import PROBLEM, Record, WARNING, INFORMATION
 from kodi_addon_checker.report import Report
 
 REL_PATH = ""
+ROOT_URL = "http://mirrors.kodi.tv/addons/{branch}/addons.xml.gz"
 LOGGER = logging.getLogger(__name__)
 
 
@@ -457,3 +458,14 @@ def _check_for_existing_addon(report: Report, addon_path, all_repo_addons):
                 return
 
     report.add(Record(INFORMATION, "This is a new addon"))
+
+
+def all_repo_addons():
+    branches = ['gotham', 'helix', 'isengard', 'jarvis', 'krypton', 'leia']
+    repo_addons = {}
+
+    for branch in branches:
+        branch_url = ROOT_URL.format(branch=branch)
+        repo_addons[branch] = _get_addons(branch_url)
+
+    return repo_addons


### PR DESCRIPTION
So we were having some issue with having an import in `__init__.py` file. So now we are shifting the `_all_repo_addons` out of the `__main__.py` file. 
There will be no change in the behaviour of the code base