### PR TITLE
Change table format

### DIFF
--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -40,7 +40,7 @@ class KodiRefactoringTool(refactor.RefactoringTool):
             if existing_line[line] != required_changes[line]:
                 self.table.append([line + 1, existing_line[line], required_changes[line]])
 
-        self.output = tabulate(self.table, headers=self.headers, tablefmt='fancy_grid')
+        self.output = tabulate(self.table, headers=self.headers, tablefmt='pipe')
         self.report.add(Record(INFORMATION, self.short_path(filepath) + '\n' + self.output))
 
 


### PR DESCRIPTION
After searching I found out that tabulate's `pipe` format is quite similar to GFM table format. Will try other formats if this one also doesn't fix the breaking table.