### PR TITLE
convert check_legacy_language_path config to branch checks

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -68,7 +68,7 @@ def start(addon_path, branch_name, all_repo_addons, pr, config=None):
 
             check_string.check_for_legacy_strings_xml(addon_report, addon_path)
 
-            if config.is_enabled("check_legacy_language_path"):
+            if branch_name not in ['gotham', 'helix']:
                 check_files.check_for_legacy_language_path(addon_report, addon_path)
 
             # Kodi 18 Leia + deprecations

--- a/kodi_addon_checker/check_files.py
+++ b/kodi_addon_checker/check_files.py
@@ -82,7 +82,7 @@ def check_for_legacy_language_path(report: Report, addon_path: str):
         for directory in dirs:
             if "resource.language." not in directory:
                 report.add(Record(
-                    WARNING, "Using the old language directory structure, please move to the new one."))
+                    PROBLEM, "Using the old language directory structure, please move to the new one."))
                 break
 
 

--- a/kodi_addon_checker/check_files.py
+++ b/kodi_addon_checker/check_files.py
@@ -79,12 +79,11 @@ def check_for_legacy_language_path(report: Report, addon_path: str):
     language_path = os.path.join(addon_path, "resources", "language")
     if os.path.exists(language_path):
         dirs = next(os.walk(language_path))[1]
-        found_warning = False
         for directory in dirs:
-            if not found_warning and "resource.language." not in directory:
+            if "resource.language." not in directory:
                 report.add(Record(
                     WARNING, "Using the old language directory structure, please move to the new one."))
-                found_warning = True
+                break
 
 
 def check_file_whitelist(report: Report, file_index: list, addon_path: str):

--- a/script.test/main.py
+++ b/script.test/main.py
@@ -108,7 +108,7 @@ def start(addon_path, repo_addons, config=None):
 
             _check_for_legacy_strings_xml(addon_report, addon_path)
 
-            if config.is_enabled("check_legacy_language_path"):
+            if branch_name not in ['gotham', 'helix']:
                 _check_for_legacy_language_path(addon_report, addon_path)
 
             # Kodi 18 Leia + deprecations

--- a/tests/fixtures/.tests-config.json
+++ b/tests/fixtures/.tests-config.json
@@ -1,4 +1,4 @@
 {
-    "check_legacy_language_path": true,
+    "true_config": true,
     "check_license_file_exists": false
 }

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -23,7 +23,7 @@ def test_if_false_gets_picked_up():
 
 def test_if_true_gets_picked_up():
     config = Config(FIXTURE_PATH)
-    assert config.is_enabled("check_legacy_language_path") is True
+    assert config.is_enabled("true_config") is True
 
 
 def test_if_does_not_exists_default_to_false():


### PR DESCRIPTION
`.tests-config.json` isn't loaded from the current working directory, but from the addon or repo path. That causes that our PR builds aren't checked for legacy language paths.