### PR TITLE
[schema validation] Only xbmc.python.script has provides tag

### DIFF
--- a/kodi_addon_checker/schema_validation.py
+++ b/kodi_addon_checker/schema_validation.py
@@ -54,7 +54,7 @@ def _validation_checks(report: Report, parsed_xml, branch_name):
         'xbmc.metadata.scraper.musicvideos': 'scraper.xsd',
         'xbmc.metadata.scraper.tvshows': 'scraper.xsd',
         'xbmc.metadata.scraper.library': 'scraper.xsd',
-        'xbmc.python.script': 'script.xsd',
+        'xbmc.python.script': 'pythonscript.xsd',
         'xbmc.python.lyrics': 'script.xsd',
         'xbmc.python.weather': 'script.xsd',
         'xbmc.python.library': 'script.xsd',

--- a/kodi_addon_checker/xml_schema/gotham_pythonscript.xsd
+++ b/kodi_addon_checker/xml_schema/gotham_pythonscript.xsd
@@ -3,6 +3,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
+      <xs:sequence>
+        <xs:element name="provides" type="providesList" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
@@ -11,7 +14,19 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="xbmc\.(python\.(library|lyrics|module|weather)|ui\.screensaver|subtitle\.module)"/>
+      <xs:pattern value="xbmc\.python\.script"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="providesList">
+    <xs:list itemType="providesType"/>
+  </xs:simpleType>
+  <xs:simpleType name="providesType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="audio"/>
+      <xs:enumeration value="executable"/>
+      <xs:enumeration value="game"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="video"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
See title.

Right now we are using the `script.xsd` schema file for `xbmc.python.script` addons and for all other scripts like `script.modules`, `screensavers`, etc. A user submitted a script.module/python library with the provides element defined and it passed CI without raising any error. In my opinion we should avoid such things passing unnoticed.

Ref: https://github.com/xbmc/repo-scripts/pull/921