### PR TITLE
[schemas] Start option was removed for leia service.addons and defaults to login

### DIFF
--- a/kodi_addon_checker/xml_schema/leia_service.xsd
+++ b/kodi_addon_checker/xml_schema/leia_service.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="extension">
+    <xs:complexType>
+      <xs:attribute name="point" type="xs:string" use="required"/>
+      <xs:attribute name="id" type="simpleIdentifier"/>
+      <xs:attribute name="name" type="xs:string"/>
+      <xs:attribute name="library" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="simpleIdentifier">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="xbmc\.service"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
In https://github.com/xbmc/xbmc/pull/13796 the old `start` attribute was removed due to profiles rework. Now all services start on login and are stopped on logout. Schemas should reflect those changes.

IMO apart from correctness this will also inform users that may be unaware of the change when they submit to Leia.