### PR TITLE
ignore .git folder in create_file_index

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -55,7 +55,7 @@ def start(addon_path, branch_name, all_repo_addons, pr, config=None):
 
             check_dependencies.check_addon_dependencies(addon_report, repo_addons, parsed_xml, branch_name)
 
-            check_files.check_file_permission(addon_report, addon_path)
+            check_files.check_file_permission(addon_report, file_index)
 
             check_files.check_for_invalid_xml_files(addon_report, file_index)
 

--- a/kodi_addon_checker/check_files.py
+++ b/kodi_addon_checker/check_files.py
@@ -121,14 +121,13 @@ def check_file_whitelist(report: Report, file_index: list, addon_path: str):
                                   relative_path(os.path.join(file["path"], file["name"]))))
 
 
-def check_file_permission(report: Report, addon_path: str):
+def check_file_permission(report: Report, file_index: list):
     """Check whether the files present in addon are marked executable
        or not
-        :addon_path: Path of the addon
+        :file_index: list having names and path of all the files present in addon
     """
 
-    files = Path(addon_path).glob('**/*')
-
-    for file in files:
+    for file in file_index:
+        file = os.path.join(file["path"], file["name"])
         if os.path.isfile(file) and os.access(str(file), os.X_OK):
             report.add(Record(PROBLEM, "%s is marked as stand-alone executable" % relative_path(str(file))))

--- a/kodi_addon_checker/handle_files.py
+++ b/kodi_addon_checker/handle_files.py
@@ -45,9 +45,11 @@ def create_file_index(path: str):
         :path: path for the directory
     """
     file_index = []
-    for dirs in os.walk(path):
-        for file_name in dirs[2]:
-            file_index.append({"path": dirs[0], "name": file_name})
+    for root, folders, files in os.walk(path, topdown=True):
+        if ".git" in folders:
+            folders.remove(".git")
+        for file_name in files:
+            file_index.append({"path": root, "name": file_name})
     return file_index
 
 

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -4,6 +4,7 @@ from os import makedirs
 from os.path import abspath, dirname, join
 
 from kodi_addon_checker.check_files import check_file_permission
+from kodi_addon_checker.handle_files import create_file_index
 
 from kodi_addon_checker.common import load_plugins
 from kodi_addon_checker.common import relative_path
@@ -25,11 +26,13 @@ class TestCheckFilePermission(unittest.TestCase):
     def test_check_file_permission_is_true(self):
         self.path = join(HERE, 'test_data', 'Executable file')
         self.string = "ERROR: .{path}/file_permission.py is marked as stand-alone executable".format(path=self.path)
-        check_file_permission(self.report, self.path)
+        file_index = create_file_index(self.path)
+        check_file_permission(self.report, file_index)
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
         flag = any(s == self.string for s in records)
         self.assertTrue(flag)
 
     def test_check_file_permission_is_None(self):
         self.path = join(HERE, 'test_data', 'Non-Executable file')
-        self.assertIsNone(check_file_permission(self.report, self.path))
+        file_index = create_file_index(self.path)
+        self.assertIsNone(check_file_permission(self.report, file_index))


### PR DESCRIPTION
Skip `.git` folder, which is inside the add-on path for single add-on repos (upstream repos), for for permission and whitelist checks.

fixes #123