### PR TITLE
add numliterals 2to3 fixer to py3 checker

### DIFF
--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -58,8 +58,22 @@ def Check_Py3_compatibility(report: Report, path: str):
         :path: path to the addon
     """
     fixer_names = []
-    list_of_fixes = ['import', 'dict', 'except', 'filter', 'has_key', 'itertools',
-                     'map', 'ne', 'next', 'print', 'renames', 'types', 'xrange', 'zip']
+    list_of_fixes = [
+                     'dict',
+                     'except',
+                     'filter',
+                     'has_key',
+                     'import',
+                     'itertools',
+                     'map',
+                     'ne',
+                     'next',
+                     'print',
+                     'renames',
+                     'types',
+                     'xrange',
+                     'zip'
+                    ]
 
     for fix in list_of_fixes:
         fixer_names.append('lib2to3.fixes.fix_' + fix)

--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -68,6 +68,7 @@ def Check_Py3_compatibility(report: Report, path: str):
                      'map',
                      'ne',
                      'next',
+                     'numliterals',
                      'print',
                      'renames',
                      'types',


### PR DESCRIPTION
https://docs.python.org/release/3.0/whatsnew/3.0.html#integers
> Octal literals are no longer of the form 0720; use 0o720 instead.

The new format is also compatible with Python 2.7.