### PR TITLE
require icon/fanart be explicitly declared in addon.xml assets

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -64,7 +64,7 @@ def start(addon_path, args, all_repo_addons, config=None):
 
             check_files.check_for_invalid_json_files(addon_report, file_index)
 
-            check_artwork.check_artwork(addon_report, addon_path, parsed_xml, file_index)
+            check_artwork.check_artwork(addon_report, addon_path, parsed_xml, file_index, args.branch)
 
             max_entrypoint_count = config.configs.get(
                 "max_entrypoint_count", 15)

--- a/kodi_addon_checker/check_artwork.py
+++ b/kodi_addon_checker/check_artwork.py
@@ -17,7 +17,7 @@ from .record import PROBLEM, Record, WARNING, INFORMATION
 LOGGER = logging.getLogger(__name__)
 
 
-def check_artwork(report: Report, addon_path: str, parsed_xml, file_index: list):
+def check_artwork(report: Report, addon_path: str, parsed_xml, file_index: list, branch_name: str):
     """Checks for icon/fanart/screenshot
         :addon_path: path to the folder having addon files
         :parsed_xml: xml file i.e addon.xml
@@ -25,7 +25,7 @@ def check_artwork(report: Report, addon_path: str, parsed_xml, file_index: list)
     """
     art_type = ['icon', 'fanart', 'screenshot']
     for image_type in art_type:
-        _check_image_type(report, image_type, parsed_xml, addon_path)
+        _check_image_type(report, image_type, parsed_xml, addon_path, branch_name)
 
     for file in file_index:
         if re.match(r"(?!fanart\.jpg|icon\.png).*\.(png|jpg|jpeg|gif)$", file["name"]) is not None:
@@ -37,7 +37,7 @@ def check_artwork(report: Report, addon_path: str, parsed_xml, file_index: list)
                     Record(PROBLEM, "Could not open image, is the file corrupted ? %s" % relative_path(image_path)))
 
 
-def _check_image_type(report: Report, image_type: str, parsed_xml, addon_path: str):
+def _check_image_type(report: Report, image_type: str, parsed_xml, addon_path: str, branch_name: str):
     """Check for whether the given image type exists or not if they do """
 
     fallback, images = _assests(image_type, parsed_xml, addon_path)
@@ -48,6 +48,9 @@ def _check_image_type(report: Report, image_type: str, parsed_xml, addon_path: s
 
             if os.path.isfile(filepath):
                 report.add(Record(INFORMATION, "Image %s exists" % image_type))
+                if fallback and branch_name not in ['gotham', 'helix', 'isengard', 'jarvis']:
+                    report.add(Record(
+                        PROBLEM, "Image %s should be explicitly declared in addon.xml <assets>." % image_type))
                 try:
                     im = Image.open(filepath)
                     width, height = im.size


### PR DESCRIPTION
Implicit fanart.jpg and icon.png in the root of the add-on directory was superseded by the explicit `assets.fanart` and `assets.icon` declarations in Kodi Krypton 17 with xbmc/xbmc#10060. There is a bit of awkward backward compatibility in Kodi core that extends to add-on lists in skins with the implicit artwork, so I'd like to generally require "assets" be used for further submissions so this back-compat can be removed at some point.

Noted on the wiki pages [Add-on structure#icon.png](https://kodi.wiki/view/Add-on_structure#icon.png) and [Addon.xml#&lt;assets&gt;](https://kodi.wiki/view/Addon.xml#.3Cassets.3E).

It should also be noted in the forums.