### PR TITLE
2to3: split fixers into required and suggested

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -71,8 +71,7 @@ def start(addon_path, branch_name, all_repo_addons, pr, config=None):
             check_entrypoint.check_complex_addon_entrypoint(
                 addon_report, addon_path, parsed_xml, max_entrypoint_count)
 
-            if branch_name not in ['gotham', 'helix', 'isengard', 'jarvis']:
-                check_py3_compatibility.check_py3_compatibility(addon_report, addon_path)
+            check_py3_compatibility.check_py3_compatibility(addon_report, addon_path, branch_name)
 
             if config.is_enabled("check_license_file_exists"):
                 # check if license file is existing

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -72,7 +72,7 @@ def start(addon_path, branch_name, all_repo_addons, pr, config=None):
                 addon_report, addon_path, parsed_xml, max_entrypoint_count)
 
             if branch_name not in ['gotham', 'helix', 'isengard', 'jarvis']:
-                check_py3_compatibility.Check_Py3_compatibility(addon_report, addon_path)
+                check_py3_compatibility.check_py3_compatibility(addon_report, addon_path)
 
             if config.is_enabled("check_license_file_exists"):
                 # check if license file is existing

--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -11,6 +11,7 @@ import os
 from lib2to3 import refactor
 from tabulate import tabulate
 
+from .common import relative_path
 from .report import Report
 from .record import Record, INFORMATION
 
@@ -20,9 +21,6 @@ class KodiRefactoringTool(refactor.RefactoringTool):
     def __init__(self, report, *args, **kwargs):
         self.report = report
         super(KodiRefactoringTool, self).__init__(*args, **kwargs)
-
-    def short_path(self, path):
-        return os.path.split(path)[1]
 
     def print_output(self, old, new, filepath, equal):
         """
@@ -49,7 +47,7 @@ class KodiRefactoringTool(refactor.RefactoringTool):
                 self.table.append([line + 1, existing_line[line], required_changes[line]])
 
         self.output = tabulate(self.table, headers=self.headers, tablefmt='pipe')
-        self.report.add(Record(INFORMATION, self.short_path(filepath) + '\n' + self.output))
+        self.report.add(Record(INFORMATION, self.relative_path(filepath) + '\n' + self.output))
 
 
 def check_py3_compatibility(report: Report, path: str):

--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -13,13 +13,14 @@ from tabulate import tabulate
 
 from .common import relative_path
 from .report import Report
-from .record import Record, INFORMATION
+from .record import Record, INFORMATION, PROBLEM
 
 
 class KodiRefactoringTool(refactor.RefactoringTool):
 
-    def __init__(self, report, *args, **kwargs):
+    def __init__(self, report, log_level, *args, **kwargs):
         self.report = report
+        self.log_level = log_level
         super(KodiRefactoringTool, self).__init__(*args, **kwargs)
 
     def print_output(self, old, new, filepath, equal):
@@ -47,33 +48,46 @@ class KodiRefactoringTool(refactor.RefactoringTool):
                 self.table.append([line + 1, existing_line[line], required_changes[line]])
 
         self.output = tabulate(self.table, headers=self.headers, tablefmt='pipe')
-        self.report.add(Record(INFORMATION, self.relative_path(filepath) + '\n' + self.output))
+        self.report.add(Record(self.log_level, relative_path(filepath) + '\n' + self.output))
 
 
-def check_py3_compatibility(report: Report, path: str):
+def check_py3_compatibility(report: Report, path: str, branch_name: str):
     """
      Checks compatibility of addons with python3
         :path: path to the addon
     """
     list_of_fixes = [
-                     'dict',
                      'except',
-                     'filter',
-                     'has_key',
-                     'import',
-                     'itertools',
-                     'map',
+                     'exec',
                      'ne',
-                     'next',
-                     'numliterals',
-                     'print',
-                     'renames',
-                     'types',
-                     'xrange',
-                     'zip'
+                     'raise',
+                     'repr',
+                     'tuple_params',
                     ]
 
     fixer_names = ['lib2to3.fixes.fix_' + fix for fix in list_of_fixes]
 
-    rt = KodiRefactoringTool(report, fixer_names, options=None, explicit=None)
+    rt = KodiRefactoringTool(report, PROBLEM, fixer_names, options=None, explicit=None)
     rt.refactor([path])
+
+    if branch_name not in ['gotham', 'helix', 'isengard', 'jarvis']:
+        list_of_fixes = [
+                        'dict',
+                        'filter',
+                        'has_key',
+                        'import',
+                        'itertools',
+                        'map',
+                        'next',
+                        'numliterals',
+                        'print',
+                        'renames',
+                        'types',
+                        'xrange',
+                        'zip',
+                        ]
+
+        fixer_names = ['lib2to3.fixes.fix_' + fix for fix in list_of_fixes]
+
+        rt = KodiRefactoringTool(report, INFORMATION, fixer_names, options=None, explicit=None)
+        rt.refactor([path])

--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -55,7 +55,6 @@ def check_py3_compatibility(report: Report, path: str):
      Checks compatibility of addons with python3
         :path: path to the addon
     """
-    fixer_names = []
     list_of_fixes = [
                      'dict',
                      'except',
@@ -74,8 +73,7 @@ def check_py3_compatibility(report: Report, path: str):
                      'zip'
                     ]
 
-    for fix in list_of_fixes:
-        fixer_names.append('lib2to3.fixes.fix_' + fix)
+    fixer_names = ['lib2to3.fixes.fix_' + fix for fix in list_of_fixes]
 
     rt = KodiRefactoringTool(report, fixer_names, options=None, explicit=None)
     rt.refactor([path])

--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -52,7 +52,7 @@ class KodiRefactoringTool(refactor.RefactoringTool):
         self.report.add(Record(INFORMATION, self.short_path(filepath) + '\n' + self.output))
 
 
-def Check_Py3_compatibility(report: Report, path: str):
+def check_py3_compatibility(report: Report, path: str):
     """
      Checks compatibility of addons with python3
         :path: path to the addon


### PR DESCRIPTION
This will report python syntax incompatibilities as error for all versions. The new syntax of those checks was backported to Python 2.6 and therefore is compatible with Gotham and newer.