### PR TITLE
add argument --allow-folder-id-mismatch to report addon_xml_matches_folder as INFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ pip install -r requirements.txt
 You can use the tool with the following options:
 ```
 
---version           version of the tool
---branch            name of the branch the tool is to run on
---PR                only when the tool is running on a pull request
+--version                   version of the tool
+--branch                    name of the branch the tool is to run on
+--PR                        only when the tool is running on a pull request
+--allow-folder-id-mismatch  allow the addon's folder name and id to mismatch
 ```

--- a/kodi_addon_checker/__main__.py
+++ b/kodi_addon_checker/__main__.py
@@ -38,7 +38,7 @@ def dir_type(dir_path):
     return os.path.abspath(dir_path)
 
 
-def check_artifact(artifact_path, args, branch_name, all_repo_addons, pr):
+def check_artifact(artifact_path, args, branch_name, all_repo_addons):
     """
     Check given artifact and return its report. The artifact can be either an add-on or a repository.
     :param artifact_path: the path of add-on or repo
@@ -52,9 +52,9 @@ def check_artifact(artifact_path, args, branch_name, all_repo_addons, pr):
     config = Config(artifact_path, args)
     ConfigManager.process_config(config)
     if os.path.isfile(os.path.join(artifact_path, "addon.xml")):
-        return check_addon.start(artifact_path, branch_name, all_repo_addons, pr, config)
+        return check_addon.start(artifact_path, branch_name, all_repo_addons, args, config)
     else:
-        return check_repo(artifact_path, branch_name, all_repo_addons, pr, config)
+        return check_repo(artifact_path, branch_name, all_repo_addons, args, config)
 
 
 def main():
@@ -74,6 +74,8 @@ def main():
     parser.add_argument("--branch", choices=choice, required=True,
                         help="Target branch name where the checker will resolve dependencies")
     parser.add_argument("--PR", help="Tell if tool is to run on a pull requests or not", action='store_true')
+    parser.add_argument("--allow-folder-id-mismatch", help="Allow the addon's folder name and id to mismatch",
+                        action="store_true")
     ConfigManager.fill_cmd_args(parser)
     args = parser.parse_args()
 
@@ -86,9 +88,9 @@ def main():
         # Following report is a wrapper for all sub reports
         report = Report("")
         for directory in args.dir:
-            report.add(check_artifact(directory, args, args.branch, all_repo_addons, args.PR))
+            report.add(check_artifact(directory, args, args.branch, all_repo_addons))
     else:
-        report = check_artifact(os.getcwd(), args, args.branch, all_repo_addons, args.PR)
+        report = check_artifact(os.getcwd(), args, args.branch, all_repo_addons)
 
     if report.problem_count > 0:
         report.add(Record(PROBLEM, "We found %s problems and %s warnings, please check the logfile." %

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -29,7 +29,7 @@ ROOT_URL = "http://mirrors.kodi.tv/addons/{branch}/addons.xml.gz"
 LOGGER = logging.getLogger(__name__)
 
 
-def start(addon_path, branch_name, all_repo_addons, pr, config=None):
+def start(addon_path, branch_name, all_repo_addons, args, config=None):
     addon_id = os.path.basename(os.path.normpath(addon_path))
     addon_report = Report(addon_id)
     LOGGER.info("Checking add-on %s" % addon_id)
@@ -42,10 +42,10 @@ def start(addon_path, branch_name, all_repo_addons, pr, config=None):
     # Extract common path from addon paths
     # All paths will be printed relative to this path
     common.REL_PATH = os.path.split(addon_path[:-1])[0]
-    addon_xml = check_files.check_addon_xml(addon_report, addon_path, parsed_xml)
+    addon_xml = check_files.check_addon_xml(addon_report, addon_path, parsed_xml, args.allow_folder_id_mismatch)
 
     if addon_xml is not None:
-        check_old_addon.check_for_existing_addon(addon_report, addon_path, all_repo_addons, pr)
+        check_old_addon.check_for_existing_addon(addon_report, addon_path, all_repo_addons, args.PR)
 
         if len(addon_xml.findall("*//broken")) == 0:
             file_index = handle_files.create_file_index(addon_path)

--- a/kodi_addon_checker/check_repo.py
+++ b/kodi_addon_checker/check_repo.py
@@ -12,7 +12,7 @@ from .record import INFORMATION, PROBLEM, Record
 from .report import Report
 
 
-def check_repo(repo_path, branch_name, all_repo_addons, pr, config):
+def check_repo(repo_path, branch_name, all_repo_addons, args, config):
     repo_report = Report(repo_path)
     repo_report.add(Record(INFORMATION, "Checking repository %s" % repo_path))
     toplevel_folders = sorted(next(os.walk(repo_path))[1])
@@ -21,7 +21,7 @@ def check_repo(repo_path, branch_name, all_repo_addons, pr, config):
         if addon_folder[0] != '.':
             addon_path = os.path.join(repo_path, addon_folder)
             try:
-                addon_report = check_addon.start(addon_path, branch_name, all_repo_addons, pr, config)
+                addon_report = check_addon.start(addon_path, branch_name, all_repo_addons, args, config)
                 repo_report.add(addon_report)
             except Exception as e:
                 repo_report.add(Record(PROBLEM, "Something went wrong. Please see: %s" % e))

--- a/tests/test_check_addon.py
+++ b/tests/test_check_addon.py
@@ -7,6 +7,11 @@ from kodi_addon_checker.reporter import ReportManager
 from kodi_addon_checker.config import Config
 
 
+class Args(object):
+    PR = False
+    allow_folder_id_mismatch = False
+
+
 class TestCheckAddon(unittest.TestCase):
     """Integration tests for Start function present in check_addon.py"""
 
@@ -20,10 +25,10 @@ class TestCheckAddon(unittest.TestCase):
         ReportManager.enable(["array"])
         self.branch_name = "krypton"
         self.all_repo_addons = all_repo_addons()
-        self.pr = False
+        self.args = Args()
 
     def test_start(self):
-        result = start(self.path, self.branch_name, self.all_repo_addons, self.pr, self.config)
+        result = start(self.path, self.branch_name, self.all_repo_addons, self.args, self.config)
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
 
         # Comparing the whitelist with the list of output we get from addon-checker tool


### PR DESCRIPTION
w/ arg:
```INFO: Addon id and folder name does not match. Ensure folder name is <addon_id> when submitting a PR to Kodi's official repository.```

w/o arg:
```ERROR: Addon id and folder name does not match.```