### PR TITLE
[check] 2to3: output changes as diff

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pillow
 requests
 radon
-tabulate
 urllib3
 xmlschema


### PR DESCRIPTION
This makes the output easier to read and understand. It can also get applied with the patch command easily.
Additionally it also handles changes of multi line statements correctly.

### old output
```
INFO: Checking add-on plugin.image.flickr
[...]
ERROR: ./plugin.image.flickr/default.py
|   # | Existing Code       | Changes required       |
|----:|:--------------------|:-----------------------|
| 866 | except HTTPError,e: | except HTTPError as e: |
| 872 | except URLError,e:  | except URLError as e:  |
ERROR: ./plugin.image.flickr/flickrapi/__init__.py
|   # | Existing Code                                                              | Changes required                                                           |
|----:|:---------------------------------------------------------------------------|:---------------------------------------------------------------------------|
| 754 | def get_token_part_two(self, (token, frob)):                               | def get_token_part_two(self, xxx_todo_changeme):                           |
| 756 |                                                                            | (token, frob) = xxx_todo_changeme                                          |
| 757 | # If a valid token was obtained in the past, we're done                    | if token:                                                                  |
| 758 | if token:                                                                  | LOG.debug("get_token_part_two: no need, token already there")              |
| 759 | LOG.debug("get_token_part_two: no need, token already there")              | self.token_cache.token = token                                             |
| 760 | self.token_cache.token = token                                             | return token                                                               |
| 761 | return token                                                               |                                                                            |
| 762 |                                                                            | LOG.debug("get_token_part_two: getting a new token for frob '%s'" % frob)  |
| 763 | LOG.debug("get_token_part_two: getting a new token for frob '%s'" % frob)  |                                                                            |
| 764 |                                                                            | return self.get_token(frob)                                                |
| 765 | return self.get_token(frob)                                                |                                                                            |
| 766 |                                                                            | def get_token(self, frob):                                                 |
| 767 | def get_token(self, frob):                                                 | '''Gets the token given a certain frob. Used by ``get_token_part_two`` and |
| 768 | '''Gets the token given a certain frob. Used by ``get_token_part_two`` and | by the web authentication method.                                          |
| 769 | by the web authentication method.                                          | '''                                                                        |
| 770 | '''                                                                        |                                                                            |
| 771 |                                                                            | # get a token                                                              |
| 772 | # get a token                                                              | rsp = self.auth_getToken(frob=frob, auth_token=None, format='xmlnode')     |
| 773 | rsp = self.auth_getToken(frob=frob, auth_token=None, format='xmlnode')     |                                                                            |
| 774 |                                                                            | token = rsp.auth[0].token[0].text                                          |
| 775 | token = rsp.auth[0].token[0].text                                          | LOG.debug("get_token: new token '%s'" % token)                             |
| 776 | LOG.debug("get_token: new token '%s'" % token)                             |                                                                            |
| 777 |                                                                            | # store the auth info for next time                                        |
| 778 | # store the auth info for next time                                        | self.token_cache.token = token                                             |
| 779 | self.token_cache.token = token                                             |                                                                            |
| 780 |                                                                            | return token                                                               |
| 781 | return token                                                               |                                                                            |
| 782 |                                                                            | def authenticate_console(self, perms='read', auth_callback=None):          |
| 783 | def authenticate_console(self, perms='read', auth_callback=None):          | '''Performs the authentication, assuming a console program.                |
| 784 | '''Performs the authentication, assuming a console program.                |                                                                            |
| 785 |                                                                            | Gets the token, if needed starts the browser and waits for the user to     |
| 786 | Gets the token, if needed starts the browser and waits for the user to     | press ENTER before continuing.                                             |
| 787 | press ENTER before continuing.                                             |                                                                            |
| 788 |                                                                            | See ``get_token_part_one(...)`` for an explanation of the                  |
| 789 | See ``get_token_part_one(...)`` for an explanation of the                  | parameters.                                                                |
| 790 | parameters.                                                                | '''                                                                        |
| 791 | '''                                                                        |                                                                            |
| 792 |                                                                            | (token, frob) = self.get_token_part_one(perms, auth_callback)              |
| 793 | (token, frob) = self.get_token_part_one(perms, auth_callback)              | if not token: raw_input("Press ENTER after you authorized this program")   |
| 794 | if not token: raw_input("Press ENTER after you authorized this program")   | self.get_token_part_two((token, frob))                                     |
| 795 | self.get_token_part_two((token, frob))                                     |                                                                            |
| 796 |                                                                            | @require_format('etree')                                                   |
| 797 | @require_format('etree')                                                   | def __data_walker(self, method, **params):                                 |
| 798 | def __data_walker(self, method, **params):                                 | '''Calls 'method' with page=0, page=1 etc. until the total                 |
| 799 | '''Calls 'method' with page=0, page=1 etc. until the total                 | number of pages has been visited. Yields the photos                        |
| 800 | number of pages has been visited. Yields the photos                        | returned.                                                                  |
| 801 | returned.                                                                  |                                                                            |
| 802 |                                                                            | Assumes that ``method(page=n, **params).findall('*/photos')``              |
| 803 | Assumes that ``method(page=n, **params).findall('*/photos')``              | results in a list of photos, and that the toplevel element of              |
| 804 | results in a list of photos, and that the toplevel element of              | the result contains a 'pages' attribute with the total number              |
| 805 | the result contains a 'pages' attribute with the total number              | of pages.                                                                  |
| 806 | of pages.                                                                  | '''                                                                        |
| 807 | '''                                                                        |                                                                            |
| 808 |                                                                            | page = 1                                                                   |
| 809 | page = 1                                                                   | total = 1 # We don't know that yet, update when needed                     |
| 810 | total = 1 # We don't know that yet, update when needed                     | while page <= total:                                                       |
| 811 | while page <= total:                                                       | # Fetch a single page of photos                                            |
| 812 | # Fetch a single page of photos                                            | LOG.debug('Calling %s(page=%i of %i, %s)' %                                |
| 813 | LOG.debug('Calling %s(page=%i of %i, %s)' %                                | (method.func_name, page, total, params))                                   |
| 814 | (method.func_name, page, total, params))                                   | rsp = method(page=page, **params)                                          |
| 815 | rsp = method(page=page, **params)                                          |                                                                            |
| 816 |                                                                            | photoset = rsp.getchildren()[0]                                            |
| 817 | photoset = rsp.getchildren()[0]                                            | total = int(photoset.get('pages'))                                         |
| 818 | total = int(photoset.get('pages'))                                         |                                                                            |
| 819 |                                                                            | photos = rsp.findall('*/photo')                                            |
| 820 | photos = rsp.findall('*/photo')                                            |                                                                            |
| 821 |                                                                            | # Yield each photo                                                         |
| 822 | # Yield each photo                                                         | for photo in photos:                                                       |
| 823 | for photo in photos:                                                       | yield photo                                                                |
| 824 | yield photo                                                                |                                                                            |
| 825 |                                                                            | # Ready to get the next page                                               |
| 826 | # Ready to get the next page                                               | page += 1                                                                  |
| 827 | page += 1                                                                  |                                                                            |
| 828 |                                                                            | @require_format('etree')                                                   |
| 829 | @require_format('etree')                                                   | def walk_set(self, photoset_id, per_page=50, **kwargs):                    |
| 830 | def walk_set(self, photoset_id, per_page=50, **kwargs):                    | '''walk_set(self, photoset_id, per_page=50, ...) -> \                      |
| 831 | '''walk_set(self, photoset_id, per_page=50, ...) -> \                      | generator, yields each photo in a single set.                              |
| 832 | generator, yields each photo in a single set.                              |                                                                            |
| 833 |                                                                            | :Parameters:                                                               |
| 834 | :Parameters:                                                               | photoset_id                                                                |
| 835 | photoset_id                                                                | the photoset ID                                                            |
| 836 | the photoset ID                                                            | per_page                                                                   |
| 837 | per_page                                                                   | the number of photos that are fetched in one call to                       |
| 838 | the number of photos that are fetched in one call to                       | Flickr.                                                                    |
| 839 | Flickr.                                                                    |                                                                            |
| 840 |                                                                            | Other arguments can be passed, as documented in the                        |
| 841 | Other arguments can be passed, as documented in the                        | flickr.photosets.getPhotos_ API call in the Flickr API                     |
| 842 | flickr.photosets.getPhotos_ API call in the Flickr API                     | documentation, except for ``page`` because all pages will be               |
| 843 | documentation, except for ``page`` because all pages will be               | returned eventually.                                                       |
| 844 | returned eventually.                                                       |                                                                            |
| 845 |                                                                            | .. _flickr.photosets.getPhotos:                                            |
| 846 | .. _flickr.photosets.getPhotos:                                            | http://www.flickr.com/services/api/flickr.photosets.getPhotos.html         |
| 847 | http://www.flickr.com/services/api/flickr.photosets.getPhotos.html         |                                                                            |
| 848 |                                                                            | Uses the ElementTree format, incompatible with other formats.              |
| 849 | Uses the ElementTree format, incompatible with other formats.              | '''                                                                        |
| 850 | '''                                                                        |                                                                            |
| 851 |                                                                            | return self.__data_walker(self.photosets_getPhotos,                        |
| 852 | return self.__data_walker(self.photosets_getPhotos,                        | photoset_id=photoset_id, per_page=per_page, **kwargs)                      |
| 853 | photoset_id=photoset_id, per_page=per_page, **kwargs)                      |                                                                            |
| 854 |                                                                            | @require_format('etree')                                                   |
| 855 | @require_format('etree')                                                   | def walk(self, per_page=50, **kwargs):                                     |
| 856 | def walk(self, per_page=50, **kwargs):                                     | '''walk(self, user_id=..., tags=..., ...) -> generator, \                  |
| 857 | '''walk(self, user_id=..., tags=..., ...) -> generator, \                  | yields each photo in a search query result                                 |
| 858 | yields each photo in a search query result                                 |                                                                            |
| 859 |                                                                            | Accepts the same parameters as flickr.photos.search_ API call,             |
| 860 | Accepts the same parameters as flickr.photos.search_ API call,             | except for ``page`` because all pages will be returned                     |
| 861 | except for ``page`` because all pages will be returned                     | eventually.                                                                |
| 862 | eventually.                                                                |                                                                            |
| 863 |                                                                            | .. _flickr.photos.search:                                                  |
| 864 | .. _flickr.photos.search:                                                  | http://www.flickr.com/services/api/flickr.photos.search.html               |
| 865 | http://www.flickr.com/services/api/flickr.photos.search.html               |                                                                            |
| 866 |                                                                            | Also see `walk_set`.                                                       |
| 867 | Also see `walk_set`.                                                       | '''                                                                        |
| 868 | '''                                                                        |                                                                            |
| 869 |                                                                            | return self.__data_walker(self.photos_search,                              |
| 870 | return self.__data_walker(self.photos_search,                              | per_page=per_page, **kwargs)                                               |
| 871 | per_page=per_page, **kwargs)                                               |                                                                            |
| 872 |                                                                            | def set_log_level(level):                                                  |
| 873 | def set_log_level(level):                                                  | '''Sets the log level of the logger used by the FlickrAPI module.          |
| 874 | '''Sets the log level of the logger used by the FlickrAPI module.          |                                                                            |
| 875 |                                                                            | >>> import flickrapi                                                       |
| 876 | >>> import flickrapi                                                       | >>> import logging                                                         |
| 877 | >>> import logging                                                         | >>> flickrapi.set_log_level(logging.INFO)                                  |
| 878 | >>> flickrapi.set_log_level(logging.INFO)                                  | '''                                                                        |
| 879 | '''                                                                        |                                                                            |
| 880 |                                                                            | import flickrapi.tokencache                                                |
| 881 | import flickrapi.tokencache                                                |                                                                            |
| 882 |                                                                            | LOG.setLevel(level)                                                        |
| 883 | LOG.setLevel(level)                                                        | flickrapi.tokencache.LOG.setLevel(level)                                   |
| 884 | flickrapi.tokencache.LOG.setLevel(level)                                   |                                                                            |
| 886 |                                                                            | if __name__ == "__main__":                                                 |
| 887 | if __name__ == "__main__":                                                 | print "Running doctests"                                                   |
| 888 | print "Running doctests"                                                   | import doctest                                                             |
| 889 | import doctest                                                             | doctest.testmod()                                                          |
| 890 | doctest.testmod()                                                          | print "Tests OK"                                                           |
[...]
```

### new output
```
INFO: Checking add-on plugin.image.flickr
[...]
ERROR: ./plugin.image.flickr/default.py
--- ./plugin.image.flickr/default.py	(original)
+++ ./plugin.image.flickr/default.py	(refactored)
@@ -863,13 +863,13 @@
             fsession.PLACES(7,woeid=url,name=name,zoom='locality')
         elif mode==1012:
             fsession.PLACES(8,woeid=url,name=name,zoom='region')
-    except HTTPError,e:
+    except HTTPError as e:
         if(e.reason[1] == 504):
             xbmcgui.Dialog().ok(__language__(30502), __language__(30504))
             success = False
         else:
             ERROR('UNHANDLED HTTP ERROR',' (HTTP)')
-    except URLError,e:
+    except URLError as e:
         LOG(e.reason)
         if(e.reason[0] == 110):
             xbmcgui.Dialog().ok(__language__(30503), __language__(30504))
ERROR: ./plugin.image.flickr/flickrapi/__init__.py
--- ./plugin.image.flickr/flickrapi/__init__.py	(original)
+++ ./plugin.image.flickr/flickrapi/__init__.py	(refactored)
@@ -751,10 +751,9 @@
 
         return (token, frob)
 
-    def get_token_part_two(self, (token, frob)):
+    def get_token_part_two(self, xxx_todo_changeme):
         """Part two of getting a token, see ``get_token_part_one(...)`` for details."""
-
-        # If a valid token was obtained in the past, we're done
+        (token, frob) = xxx_todo_changeme
         if token:
             LOG.debug("get_token_part_two: no need, token already there")
             self.token_cache.token = token
[...]
```
</details>