### PR TITLE
[fix] 2to3: catch parse exception

### DIFF
--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -8,6 +8,7 @@
 
 import os
 
+from lib2to3 import pgen2
 from lib2to3 import refactor
 import difflib
 
@@ -63,7 +64,10 @@ def check_py3_compatibility(report: Report, path: str, branch_name: str):
     fixer_names = ['lib2to3.fixes.fix_' + fix for fix in list_of_fixes]
 
     rt = KodiRefactoringTool(report, PROBLEM, fixer_names, options=None, explicit=None)
-    rt.refactor([path])
+    try:
+        rt.refactor([path])
+    except pgen2.parse.ParseError as e:
+        report.add(Record(PROBLEM, "ParseError: {}".format(e)))
 
     if branch_name not in ['gotham', 'helix', 'isengard', 'jarvis']:
         list_of_fixes = [
@@ -85,4 +89,7 @@ def check_py3_compatibility(report: Report, path: str, branch_name: str):
         fixer_names = ['lib2to3.fixes.fix_' + fix for fix in list_of_fixes]
 
         rt = KodiRefactoringTool(report, INFORMATION, fixer_names, options=None, explicit=None)
-        rt.refactor([path])
+        try:
+            rt.refactor([path])
+        except pgen2.parse.ParseError as e:
+            report.add(Record(INFORMATION, "ParseError: {}".format(e)))


### PR DESCRIPTION
This will continue the remaining addon check (check_addon.py) process if `lib2to3.pgen2.parse.ParseError` exception is thrown during the 2to3 check.