### PR TITLE
allow Python 3 compatibility check regardless of branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,5 @@ You can use the tool with the following options:
 --PR                        only when the tool is running on a pull request
 --allow-folder-id-mismatch  allow the addon's folder name and id to mismatch
 --reporter                  enable a reporter, this option can be used multiple times
+--check-python3             include Python 3 compatibility check regardless of the current branch
 ```

--- a/kodi_addon_checker/__main__.py
+++ b/kodi_addon_checker/__main__.py
@@ -75,6 +75,8 @@ def main():
     parser.add_argument("--PR", help="Tell if tool is to run on a pull requests or not", action='store_true')
     parser.add_argument("--allow-folder-id-mismatch", help="Allow the addon's folder name and id to mismatch",
                         action="store_true")
+    parser.add_argument("--check-python3", help="Include Python 3 compatibility check regardless of the current branch",
+                        action="store_true", dest="force_python3_check")
     ConfigManager.fill_cmd_args(parser)
     args = parser.parse_args()
 

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -72,7 +72,8 @@ def start(addon_path, args, all_repo_addons, config=None):
             check_entrypoint.check_complex_addon_entrypoint(
                 addon_report, addon_path, parsed_xml, max_entrypoint_count)
 
-            check_py3_compatibility.check_py3_compatibility(addon_report, addon_path, args.branch)
+            check_py3_compatibility.check_py3_compatibility(addon_report, addon_path,
+                                                            args.branch, args.force_python3_check)
 
             if config.is_enabled("check_license_file_exists"):
                 # check if license file is existing

--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -44,7 +44,7 @@ class KodiRefactoringTool(refactor.RefactoringTool):
         self.report.add(Record(self.log_level, relative_path(filename) + '\n' + diff[:-1]))
 
 
-def check_py3_compatibility(report: Report, path: str, branch_name: str):
+def check_py3_compatibility(report: Report, path: str, branch_name: str, forced: bool):
     """
      Checks compatibility of addons with python3
         :path: path to the addon
@@ -66,7 +66,7 @@ def check_py3_compatibility(report: Report, path: str, branch_name: str):
     except pgen2.parse.ParseError as e:
         report.add(Record(PROBLEM, "ParseError: {}".format(e)))
 
-    if branch_name not in ['gotham', 'helix', 'isengard', 'jarvis']:
+    if branch_name not in ['gotham', 'helix', 'isengard', 'jarvis'] or forced:
         list_of_fixes = [
                         'dict',
                         'filter',

--- a/tests/test_check_addon.py
+++ b/tests/test_check_addon.py
@@ -11,6 +11,7 @@ class Args():
     PR = False
     allow_folder_id_mismatch = False
     branch = "krypton"
+    force_python3_check = False
 
 
 class TestCheckAddon(unittest.TestCase):


### PR DESCRIPTION
YouTube, and Twitch are both Python 3 compatible but due to residing in the Isengard branch the Python 3 compatibility checks are not applied and running the checks against a higher branch results in xml schema issues.

This would allow me to apply the Python 3 checks on PRs to the add-on's repository.