### PR TITLE
[fix] iterate over repos in reverse order in check_for_existing_addon

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -47,7 +47,8 @@ def start(addon_path, args, all_repo_addons, config=None):
     addon_xml = check_files.check_addon_xml(addon_report, addon_path, parsed_xml, args.allow_folder_id_mismatch)
 
     if addon_xml is not None:
-        check_old_addon.check_for_existing_addon(addon_report, addon_path, all_repo_addons, args.PR)
+        check_old_addon.check_for_existing_addon(addon_report, addon_path, all_repo_addons, args.PR,
+                                                 KodiVersion(args.branch))
 
         if not addon_xml.findall("*//broken"):
             file_index = handle_files.create_file_index(addon_path)

--- a/kodi_addon_checker/check_old_addon.py
+++ b/kodi_addon_checker/check_old_addon.py
@@ -11,13 +11,15 @@ import os
 import xml.etree.ElementTree as ET
 from distutils.version import LooseVersion
 
+from .KodiVersion import KodiVersion
 from .record import INFORMATION, PROBLEM, Record
 from .report import Report
 
 LOGGER = logging.getLogger(__name__)
 
 
-def check_for_existing_addon(report: Report, addon_path: str, all_repo_addons: dict, pr: bool):
+def check_for_existing_addon(report: Report, addon_path: str, all_repo_addons: dict, pr: bool,
+                             kodi_version: KodiVersion):
     """Check if addon submitted already exists or not
         :addon_path: path of the addon
         :all_repo_addons: dictionary return by all_repo_addon() function
@@ -26,8 +28,8 @@ def check_for_existing_addon(report: Report, addon_path: str, all_repo_addons: d
     addon_xml = os.path.join(addon_path, "addon.xml")
     addon_name, addon_version = _get_addon_name(addon_xml)
 
-    for branch, repo in sorted(all_repo_addons.items()):
-        if addon_name in repo:
+    for branch, repo in sorted(all_repo_addons.items(), reverse=True):
+        if KodiVersion(branch) <= kodi_version and addon_name in repo:
             _check_versions(report, addon_name, branch, addon_version, repo.find(addon_name).version, pr)
             return
 


### PR DESCRIPTION
This will fix the missing error report about version being equal or lower, if the version is greater than the version in the lowest repo containing the add-on.