### PR TITLE
increase repository request timeout to 30 seconds

### DIFF
--- a/kodi_addon_checker/addons/Repository.py
+++ b/kodi_addon_checker/addons/Repository.py
@@ -20,7 +20,7 @@ class Repository():
         super(Repository, self).__init__()
         self.version = version
         self.path = path
-        content = requests.get(path, timeout=(10, 10)).content
+        content = requests.get(path, timeout=(30, 30)).content
 
         if path.endswith('.gz'):
             with gzip.open(BytesIO(content), 'rb') as xml_file:


### PR DESCRIPTION
This should reduce the connection timeout issues on PR's
The connection to the failing mirrors have required ~20 seconds in the occurrences I've checked. 