### PR TITLE
Improve addon-checker version comparison

### DIFF
--- a/kodi_addon_checker/addons/AddonDependency.py
+++ b/kodi_addon_checker/addons/AddonDependency.py
@@ -7,8 +7,7 @@
 """
 
 import xml.etree.ElementTree as ET
-from distutils.version import LooseVersion
-
+from ..versions import AddonVersion
 
 class AddonDependency():
     def __init__(self, import_xml: ET.Element):
@@ -16,5 +15,5 @@ class AddonDependency():
         self.id = import_xml.get('addon')
         self.version = None
         if import_xml.get('version') is not None:
-            self.version = LooseVersion(import_xml.get('version'))
+            self.version = AddonVersion(import_xml.get('version'))
         self.optional = import_xml.get('optional', False)

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -15,7 +15,7 @@ from . import (check_artwork, check_dependencies, check_entrypoint,
                check_string, check_url, common, handle_files,
                schema_validation, ValidKodiVersions)
 from .addons.Repository import Repository
-from .KodiVersion import KodiVersion
+from .versions import KodiVersion
 from .record import INFORMATION, Record
 from .report import Report
 

--- a/kodi_addon_checker/check_artwork.py
+++ b/kodi_addon_checker/check_artwork.py
@@ -14,9 +14,10 @@ from collections import namedtuple
 from PIL import Image
 
 from .common import has_transparency, relative_path
-from .KodiVersion import KodiVersion
 from .record import INFORMATION, PROBLEM, WARNING, Record
 from .report import Report
+from .versions import KodiVersion
+
 
 LOGGER = logging.getLogger(__name__)
 

--- a/kodi_addon_checker/check_dependencies.py
+++ b/kodi_addon_checker/check_dependencies.py
@@ -7,12 +7,12 @@
 """
 
 import logging
-from distutils.version import LooseVersion
 
 from .addons.Addon import Addon
-from .KodiVersion import KodiVersion
 from .record import INFORMATION, PROBLEM, WARNING, Record
 from .report import Report
+from .versions import AddonVersion, KodiVersion
+
 
 common_ignore_deps = ['xbmc.metadata.scraper.albums', 'xbmc.metadata.scraper.movies',
                       'xbmc.metadata.scraper.musicvideos', 'xbmc.metadata.scraper.tvshows',
@@ -88,7 +88,7 @@ def check_addon_dependencies(report: Report, repo_addons: dict, parsed_xml, bran
                               .format("Optional" if dependency.optional else "Required", dependency.id,
                                       repo_addons.find(dependency.id).version)))
 
-        elif repo_addons.find(dependency.id).version < dependency.version:
+        elif AddonVersion(repo_addons.find(dependency.id).version) < dependency.version:
             report.add(Record(INFORMATION if dependency.optional else PROBLEM,
                               "Version mismatch for {} dependency {}, required: {}, Available: {}"
                               .format("optional" if dependency.optional else "required", dependency.id,
@@ -97,13 +97,13 @@ def check_addon_dependencies(report: Report, repo_addons: dict, parsed_xml, bran
         if dependency.id in VERSION_ATTRB:
             try:
                 version_info = VERSION_ATTRB[dependency.id][branch_name]
-                if LooseVersion(version_info["min_compatible"]) > dependency.version:
+                if AddonVersion(version_info["min_compatible"]) > dependency.version:
                     report.add(Record(PROBLEM, "For {}, {} version must be higher than {}. Advised {}."
                                       .format(branch_name, dependency.id,
                                               version_info["min_compatible"], version_info["advised"])))
                     continue
 
-                if LooseVersion(version_info["advised"]) != dependency.version:
+                if AddonVersion(version_info["advised"]) != dependency.version:
                     report.add(Record(WARNING, "For {} it is advised to set {} version to {}"
                                       .format(branch_name, dependency.id, version_info["advised"])))
 

--- a/kodi_addon_checker/check_old_addon.py
+++ b/kodi_addon_checker/check_old_addon.py
@@ -9,11 +9,11 @@
 import logging
 import os
 import xml.etree.ElementTree as ET
-from distutils.version import LooseVersion
 
-from .KodiVersion import KodiVersion
 from .record import INFORMATION, PROBLEM, Record
 from .report import Report
+from .versions import AddonVersion, KodiVersion
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,15 +59,15 @@ def _check_versions(report: Report, addon_details, branch, repo_addons_version, 
     addon_version = addon_details.get('version')
 
     if pr:
-        if LooseVersion(addon_version) > LooseVersion(repo_addons_version):
+        if AddonVersion(addon_version) > AddonVersion(repo_addons_version):
             LOGGER.info("%s addon have greater version: %s than repo_version: %s in branch %s",
                         addon_name, addon_version, repo_addons_version, branch)
         else:
-            report.add(Record(PROBLEM, "%s addon already exists with version: %s in %s branch"
+            report.add(Record(PROBLEM, "%s addon already exists with a higher version: %s in %s branch"
                               % (addon_name, repo_addons_version, branch)))
     else:
-        if LooseVersion(addon_version) < LooseVersion(repo_addons_version):
-            report.add(Record(PROBLEM, "%s addon already exist with version: %s in %s branch"
+        if AddonVersion(addon_version) < AddonVersion(repo_addons_version):
+            report.add(Record(PROBLEM, "%s addon already exist with a higher version: %s in %s branch"
                               % (addon_name, repo_addons_version, branch)))
         else:
             report.add(Record(INFORMATION, "%s addon also exists in %s branch but with version: %s"

--- a/kodi_addon_checker/check_py3_compatibility.py
+++ b/kodi_addon_checker/check_py3_compatibility.py
@@ -10,9 +10,9 @@ import difflib
 from lib2to3 import pgen2, refactor
 
 from .common import relative_path
-from .KodiVersion import KodiVersion
 from .record import INFORMATION, PROBLEM, Record
 from .report import Report
+from .versions import KodiVersion
 
 
 class KodiRefactoringTool(refactor.RefactoringTool):

--- a/kodi_addon_checker/versions.py
+++ b/kodi_addon_checker/versions.py
@@ -6,7 +6,40 @@
     See LICENSES/README.md for more information.
 """
 
-from . import ValidKodiVersions
+from packaging.version import parse
+from kodi_addon_checker import ValidKodiVersions
+
+
+class AddonVersion():
+    def __init__(self, version):
+        self.version = parse(str(version))
+
+    def __lt__(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError()
+        return self.version < other.version
+
+    def __le__(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError()
+        return self.version <= other.version
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.version == other.version
+
+    def __ne__(self, other):
+        return not isinstance(other, self.__class__) or self.version != other.version
+
+    def __gt__(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError()
+        return self.version > other.version
+
+    def __ge__(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError()
+        return self.version >= other.versionß
+
 
 class KodiVersion():
     def __init__(self, version: str):

--- a/script.test/main.py
+++ b/script.test/main.py
@@ -10,7 +10,6 @@ import os
 import pathlib
 import re
 from radon.raw import analyze
-from distutils.version import LooseVersion
 import xml.etree.ElementTree as ET
 
 from PIL import Image
@@ -18,6 +17,7 @@ from PIL import Image
 from kodi_addon_checker.common import has_transparency
 from kodi_addon_checker.record import PROBLEM, Record, WARNING, INFORMATION
 from kodi_addon_checker.report import Report
+from kodi_addon_checker.versions import AddonVersion
 
 import logging
 import xbmcaddon
@@ -382,6 +382,6 @@ def _check_dependencies(report: Report, addon_path, repo_addons):
         else:
             available_version = repo_addons[required_addon]
 
-            if LooseVersion(available_version) < LooseVersion(required_version) and (required_addon not in ignore):
+            if AddonVersion(available_version) < AddonVersion(required_version) and (required_addon not in ignore):
                 report.add(Record(PROBLEM, "Version mismatch for addon %s. Required: %s, Available: %s "
                                   % (required_addon, required_version, available_version)))

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+
+from kodi_addon_checker.versions import AddonVersion, KodiVersion
+
+
+def test_addonversion_simple_patch():
+    assert AddonVersion("1.0.1") > AddonVersion("1.0.0")
+
+
+def test_addonversion_simple_minor():
+    assert AddonVersion("1.1.0") > AddonVersion("1.0.0")
+
+
+def test_addonversion_simple_major():
+    assert AddonVersion("2.0.0") > AddonVersion("1.0.0")
+
+
+def test_addonversion_kodi_versions():
+    assert AddonVersion("1.0.0+matrix.1") > AddonVersion("1.0.0+leia.1")
+
+
+def test_addonversion_kodi_simplevsstring():
+    assert AddonVersion("0.5.4.1") > AddonVersion("0.5.4+matrix.1")
+
+
+def test_kodiversions():
+    assert KodiVersion("matrix") > KodiVersion("leia")


### PR DESCRIPTION
To fix https://github.com/xbmc/repo-scripts/pull/1356

`distutils.version` is not a robust way to do version comparison. This has been already raised to python core and the patch was denied: https://bugs.python.org/issue30272

This changes the implementation to rely on `packaging.version` which has a much more robust algorithm.

This PR also changes `KodiVersion.py` to `versions.py` for consistency. `LooseVersion` is now `AddonVersion` and centralized on `versions.py`. Tests added to make sure this won't break in the future.