### PR TITLE
add packaging to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+packaging
 pillow
 polib
 requests


### PR DESCRIPTION
Travis seems to fail in some cases with current master. `ModuleNotFoundError: No module named 'packaging'`
 
https://travis-ci.org/github/MrSprigster/script.module.python.twitch/builds/668141515?utm_source=github_status&utm_medium=notification
