### PR TITLE
Improve version mismatch representation

### DIFF
--- a/kodi_addon_checker/versions.py
+++ b/kodi_addon_checker/versions.py
@@ -40,6 +40,9 @@ class AddonVersion():
             raise TypeError()
         return self.version >= other.version
 
+    def __repr__(self):
+        return str(self.version)
+
 
 class KodiVersion():
     def __init__(self, version: str):


### PR DESCRIPTION
When the addon-checker errors out due to a dependency version mismatch, the `AddonVersion` object should return the version as a string and not the object itself. Fixes a minor identified by @anxdpanic in https://travis-ci.org/github/MrSprigster/Twitch-on-Kodi/builds/668410076#L269