### PR TITLE
Don't check for file permissions on Windows

### DIFF
--- a/kodi_addon_checker/check_files.py
+++ b/kodi_addon_checker/check_files.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 
 from . import handle_files
 from .common import relative_path
+from .common.decorators import posix_only
 from .record import INFORMATION, PROBLEM, WARNING, Record
 from .report import Report
 
@@ -129,6 +130,7 @@ def check_file_whitelist(report: Report, file_index: list, addon_path: str):
                                   relative_path(os.path.join(file["path"], file["name"]))))
 
 
+@posix_only
 def check_file_permission(report: Report, file_index: list):
     """Check whether the files present in addon are marked executable
        or not

--- a/kodi_addon_checker/common/__init__.py
+++ b/kodi_addon_checker/common/__init__.py
@@ -6,6 +6,8 @@
     See LICENSES/README.md for more information.
 """
 
+__all__ = ["decorators", "has_transparency", "relative_path", "load_plugins"]
+
 import importlib
 import os
 import pkgutil
@@ -35,7 +37,7 @@ def has_transparency(im):
 def load_plugins():
     """Load the reporter plugins
     """
-    plugins_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "plugins")
+    plugins_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "plugins")
     sys.path.append(plugins_dir)
     for _, package_name, _ in pkgutil.iter_modules([plugins_dir]):
         if "test_" not in package_name:

--- a/kodi_addon_checker/common/decorators.py
+++ b/kodi_addon_checker/common/decorators.py
@@ -1,0 +1,20 @@
+"""
+    Copyright (C) 2017-2018 Team Kodi
+    This file is part of Kodi - kodi.tv
+
+    SPDX-License-Identifier: GPL-3.0-only
+    See LICENSES/README.md for more information.
+"""
+
+import os
+
+
+class posix_only():
+    def __init__(self, f):
+        self.f = f
+
+    def __call__(self, *args, **kwargs):
+        if os.name == "nt":
+            return
+
+        self.f(*args, **kwargs)

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from os.path import abspath, dirname, join
 
@@ -29,7 +30,10 @@ class TestCheckFilePermission(unittest.TestCase):
         check_file_permission(self.report, file_index)
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
         flag = any(s == string for s in records)
-        self.assertTrue(flag)
+        if os.name == "nt":
+            self.assertFalse(flag)
+        else:
+            self.assertTrue(flag)
 
     def test_check_file_permission_is_None(self):
         path = join(HERE, 'test_data', 'Non-Executable_file')


### PR DESCRIPTION
There is no need to check for file permissions on windows. It now shows a lot of errors because all files are executable on Windows.