### PR TITLE
[Versions] Support legacy non-compliant PEP440 development versions 

### DIFF
--- a/kodi_addon_checker/versions.py
+++ b/kodi_addon_checker/versions.py
@@ -6,13 +6,22 @@
     See LICENSES/README.md for more information.
 """
 
-from packaging.version import parse
+from packaging.version import parse, Version, LegacyVersion
 from kodi_addon_checker import ValidKodiVersions
 
 
 class AddonVersion():
     def __init__(self, version):
         self.version = parse(str(version))
+        # non PEP440 compliant versions (legacy), for beta and alpha versions
+        # convert them into PEP440 format: 1.1.0~beta01 -> 1.1.0beta01
+        if self._islegacy_devversion:
+            self.version = Version(version.replace("~", ""))
+
+    @property
+    def _islegacy_devversion(self):
+        return isinstance(self.version, LegacyVersion) and \
+            ("~beta" or "~alpha" in self.version)
 
     def __lt__(self, other):
         if not isinstance(other, self.__class__):

--- a/kodi_addon_checker/versions.py
+++ b/kodi_addon_checker/versions.py
@@ -12,7 +12,7 @@ from kodi_addon_checker import ValidKodiVersions
 
 class AddonVersion():
     def __init__(self, version):
-        self.version = parse(str(version))
+        self.version = parse(str(version).lower())
         # non PEP440 compliant versions (legacy), for beta and alpha versions
         # convert them into PEP440 format: 1.1.0~beta01 -> 1.1.0beta01
         if self._islegacy_devversion:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -24,5 +24,17 @@ def test_addonversion_kodi_simplevsstring():
     assert AddonVersion("0.5.4.1") > AddonVersion("0.5.4+matrix.1")
 
 
+def test_kodi_non_compliant_pep440_builtin_versions():
+    # mimics the tests in TestAddonVersion.cpp (non PEP440 compliant)
+    # try to use PEP440 compliant versions whenever possible
+    assert AddonVersion("1.0.0-1") > AddonVersion("1.0.0")
+    assert AddonVersion("1.0.0~beta2") > AddonVersion("1.0.0~beta1")
+    assert AddonVersion("1.0.1~beta01") > AddonVersion("1.0.0")
+    assert AddonVersion("1.0.1~beta") > AddonVersion("1.0.0")
+    assert AddonVersion("1.0.0~beta") > AddonVersion("1.0.0~alpha")
+    assert AddonVersion("1.0.0~beta2") > AddonVersion("1.0.0~alpha")
+    assert AddonVersion("1.0.0~alpha3") > AddonVersion("1.0.0~alpha2")
+
+
 def test_kodiversions():
     assert KodiVersion("matrix") > KodiVersion("leia")

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -18,6 +18,7 @@ def test_addonversion_simple_major():
 
 def test_addonversion_kodi_versions():
     assert AddonVersion("1.0.0+matrix.1") > AddonVersion("1.0.0+leia.1")
+    assert AddonVersion("1.0.0+leia.1") == AddonVersion("1.0.0+Leia.1")
 
 
 def test_addonversion_kodi_simplevsstring():


### PR DESCRIPTION
Fixes https://github.com/xbmc/addon-check/issues/224

Kodi supports non-PEP440 compliant version for development purposes, eg:

`1.0.1~beta`
`1.0.1~beta01`
etc

As those are not PEP440 compliant, the `packaging.version` module parses the version to `LegacyVersion` objects instead of `Version` objects. When the comparator compares both objects, `LegacyVersion` is always lower.

This is solved by ensuring that when a version string like those above is supplied to addon-checker (thus containing `~alpha` or `~beta`) and the resulting object is a `LegacyVersion`, the `AddonVersion` class does an implicit conversion to the PEP440 format: `x.x.xalphay`.

Tests added to mimic the ones in Kodi.