### PR TITLE
[Artwork] Allow screenshots and banners in png

### DIFF
--- a/kodi_addon_checker/check_artwork.py
+++ b/kodi_addon_checker/check_artwork.py
@@ -56,7 +56,7 @@ def check_artwork(report: Report, addon_path: str, parsed_xml, file_index: list,
         Asset(
             'screenshot',
             {
-                'extension': [".jpg", ".jpeg"],
+                'extension': [".jpg", ".jpeg", ".png"],
                 'transparency': False,
                 'sizes': [(1280, 720), (1920, 1080)],
                 'max_file_size': 750
@@ -65,7 +65,7 @@ def check_artwork(report: Report, addon_path: str, parsed_xml, file_index: list,
         Asset(
             'banner',
             {
-                'extension': [".jpg", ".jpeg"],
+                'extension': [".jpg", ".jpeg", ".png"],
                 'transparency': False,
                 'sizes': [(1000, 185)],
                 'max_file_size': None


### PR DESCRIPTION
Since @anxdpanic added file size checks for artwork, there's absolute no reason to force developers to use .jpg files for screenshots and banners.

Wiki has already been edited:
https://kodi.wiki/view/Add-on_structure#resources.2Fscreenshot-x.jpg_.28optional.29
https://kodi.wiki/view/Add-on_structure#resources.2Fbanner.jpg_.28optional.29