### PR TITLE
Added check for duplicate context menu libraries/args

### DIFF
--- a/kodi_addon_checker/xml_schema/matrix_contextitem.xsd
+++ b/kodi_addon_checker/xml_schema/matrix_contextitem.xsd
@@ -8,6 +8,7 @@
           <xs:unique name="oneLibraryOnly">
             <xs:selector xpath="./*"/>
             <xs:field xpath="@library"/>
+            <xs:field xpath="@args"/>
           </xs:unique>
         </xs:element>
       </xs:sequence>
@@ -21,6 +22,7 @@
       <xs:element name="visible" type="xs:string" minOccurs="1"/>
     </xs:all>
     <xs:attribute name="library" type="xs:string" use="required"/>
+    <xs:attribute name="args" type="xs:string"/>
   </xs:complexType>
   <xs:complexType name="menuType">
     <xs:choice maxOccurs="unbounded">


### PR DESCRIPTION
I added an option to validate that the context menu items in the addon.xml do not define duplicate `library` parameters (for Leia and down) or `library`/`args` combinations for Matrix (See https://github.com/xbmc/xbmc/pull/17631)