### PR TITLE
Add .ico to whitelist (favicon.ico)

### DIFF
--- a/kodi_addon_checker/check_files.py
+++ b/kodi_addon_checker/check_files.py
@@ -117,7 +117,7 @@ def check_file_whitelist(report: Report, file_index: list, addon_path: str):
     whitelist = (
         r"\.?(py|xml|gif|png|jpg|jpeg|md|txt|po|json|gitignore|markdown|yml|"
         r"rst|ini|flv|wav|mp4|html|css|lst|pkla|g|template|in|cfg|xsd|directory|"
-        r"help|list|mpeg|pls|info|ttf|xsp|theme|yaml|dict|crt)?$"
+        r"help|list|mpeg|pls|info|ttf|xsp|theme|yaml|dict|crt|ico)?$"
     )
 
     for file in file_index:


### PR DESCRIPTION
We have webinterface addons and other addons that also include webinterfaces. They include favicons, so make sure .ico extension is whitelisted