### PR TITLE
Improve language folder layout check for versions below isengard

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -84,7 +84,9 @@ def start(addon_path, args, all_repo_addons, config=None):
             check_string.check_for_legacy_strings_xml(addon_report, addon_path)
 
             if KodiVersion(args.branch) >= KodiVersion("isengard"):
-                check_files.check_for_legacy_language_path(addon_report, addon_path)
+                check_files.check_for_new_language_directory_structure(addon_report, addon_path)
+            else:
+                check_files.check_for_new_language_directory_structure(addon_report, addon_path, supported=False)
 
             check_string.check_for_invalid_strings_po(addon_report, file_index)
 

--- a/kodi_addon_checker/check_files.py
+++ b/kodi_addon_checker/check_files.py
@@ -90,18 +90,25 @@ def addon_xml_matches_folder(report: Report, addon_path: str, parsed_xml, folder
             report.add(Record(PROBLEM, "Addon id and folder name does not match."))
 
 
-def check_for_legacy_language_path(report: Report, addon_path: str):
+def check_for_new_language_directory_structure(report: Report, addon_path: str, supported=True):
     """Check whether the language directory structure is new or not
         :addon_path: path to addon folder
+        :supported: if we should error out in case the new language format is not supported
+        by the respective kodiversion
     """
     language_path = os.path.join(addon_path, "resources", "language")
     if os.path.exists(language_path):
         dirs = next(os.walk(language_path))[1]
         for directory in dirs:
-            if "resource.language." not in directory:
+            if "resource.language." not in directory and supported:
                 report.add(Record(
-                    PROBLEM, "Using the old language directory structure, please move to the new one."))
-                break
+                    PROBLEM, "Using the old language directory structure in %s, please move to the new one." %
+                    os.path.join(language_path, directory)))
+            elif "resource.language." in directory and not supported:
+                report.add(Record(
+                    PROBLEM, "Using the new language directory structure in %s for a Kodi version that does not" \
+                             "support it. Please use the old language file struture or move the addon to" \
+                             "an upper branch/kodi version." % os.path.join(language_path, directory)))
 
 
 def check_file_whitelist(report: Report, file_index: list, addon_path: str):

--- a/script.test/main.py
+++ b/script.test/main.py
@@ -108,7 +108,9 @@ def start(addon_path, repo_addons, config=None):
             _check_for_legacy_strings_xml(addon_report, addon_path)
 
             if branch_name not in ['gotham', 'helix']:
-                _check_for_legacy_language_path(addon_report, addon_path)
+                check_for_new_language_directory_structure(addon_report, addon_path)
+            else:
+                check_for_new_language_directory_structure(addon_report, addon_path, supported=False)
 
             # Kodi 18 Leia + deprecations
             if config.is_enabled("check_kodi_leia_deprecations"):
@@ -287,14 +289,22 @@ def _find_blacklisted_strings(report: Report, addon_path, problem_list, warning_
                           % (result["term"], result["searchfile"], result["linenumber"], result["line"])))
 
 
-def _check_for_legacy_language_path(report: Report, addon_path):
+def check_for_new_language_directory_structure(report: Report, addon_path, supported=True):
     language_path = os.path.join(addon_path, "resources", "language")
     if os.path.exists(language_path):
         dirs = next(os.walk(language_path))[1]
         found_warning = False
-        for dir in dirs:
-            if not found_warning and "resource.language." not in dir:
-                report.add(Record(WARNING, "Using the old language directory structure, please move to the new one."))
+        for directory in dirs:
+            if not found_warning and "resource.language." not in directory and supported:
+                report.add(Record(
+                    WARNING, "Using the old language directory structure in %s, please move to the new one." %
+                    os.path.join(language_path, directory)))
+                found_warning = True
+            elif not found_warning "resource.language." in directory and not supported:
+                report.add(Record(
+                    WARNING, "Using the new language directory structure in %s for a Kodi version that does not" \
+                             "support it. Please use the old language file struture or move the addon to" \
+                             "an upper branch/kodi version." % os.path.join(language_path, directory)))
                 found_warning = True
 
 


### PR DESCRIPTION
Currently we only check if in versions higher or equal to isengard the addon includes the new language folder layout. However, we don't to anything for version between gotham and isengard. If an addon update sends a "new folder layout" for gotham and helix, kodi won't be able to use them, so error out.