### PR TITLE
Improve forward-version/migration checks

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -14,6 +14,7 @@ from . import (check_artwork, check_dependencies, check_entrypoint,
                check_files, check_addon_branches, check_py3_compatibility,
                check_string, check_url, common, handle_files,
                schema_validation, ValidKodiVersions)
+from .addons.Addon import Addon
 from .addons.Repository import Repository
 from .versions import KodiVersion
 from .record import INFORMATION, Record
@@ -47,8 +48,7 @@ def start(addon_path, args, all_repo_addons, config=None):
     addon_xml = check_files.check_addon_xml(addon_report, addon_path, parsed_xml, args.allow_folder_id_mismatch)
 
     if addon_xml is not None:
-        check_addon_branches.check_for_existing_addon(addon_report, addon_path, all_repo_addons, args.PR,
-                                                      KodiVersion(args.branch))
+        check_addon_branches.check_for_existing_addon(addon_report, Addon(parsed_xml), all_repo_addons, args)
 
         if not addon_xml.findall("*//broken"):
             file_index = handle_files.create_file_index(addon_path)

--- a/kodi_addon_checker/check_dependencies.py
+++ b/kodi_addon_checker/check_dependencies.py
@@ -56,7 +56,43 @@ VERSION_ATTRB = {
         'krypton': {'min_compatible': '2.1.0', 'advised': '2.25.0'},
         'leia': {'min_compatible': '2.1.0', 'advised': '2.26.0'},
         'matrix': {'min_compatible': '3.0.0', 'advised': '3.0.0'}
-    }
+    },
+    'xbmc.gui': {
+        'gotham': {'min_compatible': '5.0.0', 'advised': '5.0.0'},
+        'helix': {'min_compatible': '5.3.0', 'advised': '5.3.0'},
+        'isengard': {'min_compatible': '5.3.0', 'advised': '5.9.0'},
+        'jarvis': {'min_compatible': '5.10.0', 'advised': '5.10.0'},
+        'krypton': {'min_compatible': '5.12.0', 'advised': '5.12.0'},
+        'leia': {'min_compatible': '5.14.0', 'advised': '5.14.0'},
+        'matrix': {'min_compatible': '5.14.0', 'advised': '5.15.0'}
+    },
+    'xbmc.json': {
+        'gotham': {'min_compatible': '6.0.0', 'advised': '5.0.0'},
+        'helix': {'min_compatible': '6.0.0', 'advised': '6.20.0'},
+        'isengard': {'min_compatible': '6.0.0', 'advised': '6.25.1'},
+        'jarvis': {'min_compatible': '6.0.0', 'advised': '6.32.4'},
+        'krypton': {'min_compatible': '6.0.0', 'advised': '7.0.0'},
+        'leia': {'min_compatible': '6.0.0', 'advised': '9.7.2'},
+        'matrix': {'min_compatible': '6.0.0', 'advised': '11.2.0'}
+    },
+    'xbmc.addon': {
+        'gotham': {'min_compatible': '12.0.0', 'advised': '13.0.0'},
+        'helix': {'min_compatible': '12.0.0', 'advised': '14.0.0'},
+        'isengard': {'min_compatible': '12.0.0', 'advised': '15.0.0'},
+        'jarvis': {'min_compatible': '12.0.0', 'advised': '16.0.0'},
+        'krypton': {'min_compatible': '12.0.0', 'advised': '17.0.0'},
+        'leia': {'min_compatible': '12.0.0', 'advised': '17.9.910'},
+        'matrix': {'min_compatible': '12.0.0', 'advised': '18.9.701'}
+    },
+    'xbmc.metadata': {
+        'gotham': {'min_compatible': '1.0', 'advised': '2.1.0'},
+        'helix': {'min_compatible': '1.0', 'advised': '2.1.0'},
+        'isengard': {'min_compatible': '1.0', 'advised': '2.1.0'},
+        'jarvis': {'min_compatible': '1.0', 'advised': '2.1.0'},
+        'krypton': {'min_compatible': '1.0', 'advised': '2.1.0'},
+        'leia': {'min_compatible': '1.0', 'advised': '2.1.0'},
+        'matrix': {'min_compatible': '1.0', 'advised': '2.1.0'}
+    },
 }
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Unfortunately the last approach do not work for all addons, causing problems in the repo-scrappers repository. The repository generator places clones of the same addon on upper branches if their dependencies are abi backwards compatible.
Means that if you push a xml scrapper to gotham branch, the same version will also be available in matrix branch (I mean in the addons.xml.gz and not in github). Addon-checker errors out because it sees the matrix addon as non-migration compatible (same addon version). This happens because we are blindly making that decision on the fact `xbmc.python` is not forward compatible between target and matrix - but the addon might not depend on xbmc.python at all.

So this PR changes the check to make it more generic, it looks over all the xbmc api dependencies (xbmc.python, xbmc.gui, xbmc.metadata, etc) and checks if they are forward compatible between the repo to which the addon is being submitted and the "upper branch" that also contains the addon (and just if the addon actually depend on any of them).