### PR TITLE
Language: Do not validate paths in check_for_invalid_strings_po if us…

### DIFF
--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -90,7 +90,7 @@ def start(addon_path, args, all_repo_addons, config=None):
             else:
                 check_files.check_for_new_language_directory_structure(addon_report, addon_path, supported=False)
 
-            check_string.check_for_invalid_strings_po(addon_report, file_index, addon_path)
+            check_string.check_for_invalid_strings_po(addon_report, file_index)
 
             # Kodi 18 Leia + deprecations
             if config.is_enabled("check_kodi_leia_deprecations"):

--- a/tests/test_check_po_files.py
+++ b/tests/test_check_po_files.py
@@ -28,7 +28,7 @@ class TestPOFiles(unittest.TestCase):
         file_index = [{"path": language_path, "name": "strings.po"}]
 
         expected = []
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
         output = [s for s in records if s.startswith(self.report_matches)]
@@ -48,7 +48,7 @@ class TestPOFiles(unittest.TestCase):
                     'Missing required header:\n'
                     '\tmsgid ""\n\tmsgstr ""'.format(path=relative_path(full_path))]
 
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
         output = [s for s in records if s.startswith(self.report_matches)]
@@ -67,7 +67,7 @@ class TestPOFiles(unittest.TestCase):
         expected = ["ERROR: Invalid PO file {path}: "
                     "Syntax error on line 23".format(path=relative_path(full_path))]
 
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
         output = [s for s in records if s.startswith(self.report_matches)]
@@ -86,7 +86,7 @@ class TestPOFiles(unittest.TestCase):
         expected = ["ERROR: Invalid PO file {path}: "
                     "File is not saved with UTF-8 encoding".format(path=relative_path(full_path))]
 
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
         output = [s for s in records if s.startswith(self.report_matches)]
@@ -105,7 +105,7 @@ class TestPOFiles(unittest.TestCase):
         expected = ["ERROR: Invalid PO file {path}: "
                     "File contains BOM (byte order mark)".format(path=relative_path(full_path))]
 
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
         output = [s for s in records if s.startswith(self.report_matches)]
@@ -123,7 +123,7 @@ class TestPOFiles(unittest.TestCase):
 
         expected = ["ERROR: Invalid PO file {path}: File is empty".format(path=relative_path(full_path))]
 
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         records = [Record.__str__(r) for r in ReportManager.getEnabledReporters()[0].reports]
         output = [s for s in records if s.startswith(self.report_matches)]
@@ -144,7 +144,7 @@ class TestPOFiles(unittest.TestCase):
                 .format(path=relative_path(join(language_path, "resources.language.en_gb", "strings.po"))),
         ]
 
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         matches = (
             self.report_matches,
@@ -169,7 +169,7 @@ class TestPOFiles(unittest.TestCase):
                 .format(path=relative_path(join(language_path, "resource.language.testing", "strings.po")))
         ]
 
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         matches = (
             self.report_matches,
@@ -193,7 +193,7 @@ class TestPOFiles(unittest.TestCase):
             "ERROR: Required default language 'en_gb' is not present."
         ]
 
-        check_for_invalid_strings_po(self.report, file_index, path)
+        check_for_invalid_strings_po(self.report, file_index)
 
         matches = (
             self.report_matches,


### PR DESCRIPTION
…ing legacy language folder layouts

Restores functionality for https://github.com/xbmc/repo-scripts/pull/1850

Note language folder layout is already validated in check_for_new_language_directory_structure, no need to error out in these methods if using the older language folder layout for an addon (< isengard). We're trying to validate the gettext structure not exactly the folder structure