### PR TITLE
Simplify and fix condition for addon versions

### DIFF
--- a/kodi_addon_checker/check_addon_branches.py
+++ b/kodi_addon_checker/check_addon_branches.py
@@ -94,8 +94,7 @@ def _check_version_higher(report: Report, addon_details, branch, repo_addons_ver
     addon_name = addon_details.get('name')
     addon_version = addon_details.get('version')
 
-    if AddonVersion(addon_version) < AddonVersion(repo_addons_version) or \
-        (AddonVersion(addon_version) == AddonVersion(repo_addons_version) and pr):
+    if AddonVersion(addon_version) <= AddonVersion(repo_addons_version) and pr:
         report.add(
             Record(
                 PROBLEM,


### PR DESCRIPTION
Condition should only be evaluated if a PR is being performed otherwise we are reporting errors for regular CI workflows (e.g. checks after a PR or merge to master)