### PR TITLE
Check if addon version is compliant with repository generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It can also be used locally for detecting problems in your addons.
 
 - Checks if addon.xml and license file exists for an addon.
 
+- Checks if the version in addon.xml is valid (for repository generator)
+
 - Checks if all xml files are valid.
 
 - Check if all the json files are valid.

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -10,10 +10,10 @@ import logging
 import os
 import xml.etree.ElementTree as ET
 
-from . import (check_artwork, check_dependencies, check_entrypoint,
-               check_files, check_addon_branches, check_py3_compatibility,
-               check_string, check_url, common, handle_files,
-               schema_validation, ValidKodiVersions)
+from . import (check_allowed_versions, check_artwork, check_dependencies,
+               check_entrypoint, check_files, check_addon_branches,
+               check_py3_compatibility, check_string, check_url, common,
+               handle_files, schema_validation, ValidKodiVersions)
 from .addons.Addon import Addon
 from .addons.Repository import Repository
 from .versions import KodiVersion
@@ -42,6 +42,8 @@ def start(addon_path, args, all_repo_addons, config=None):
     addon_xml_path = os.path.join(addon_path, "addon.xml")
     parsed_xml = ET.parse(addon_xml_path).getroot()
 
+    # check if provided version for the addon is allowed
+    check_allowed_versions.check_version(addon_report, parsed_xml)
     # Extract common path from addon paths
     # All paths will be printed relative to this path
     common.REL_PATH = os.path.split(addon_path[:-1])[0]

--- a/kodi_addon_checker/check_allowed_versions.py
+++ b/kodi_addon_checker/check_allowed_versions.py
@@ -1,0 +1,43 @@
+"""
+    Copyright (C) 2021 Team Kodi
+    This file is part of Kodi - kodi.tv
+
+    SPDX-License-Identifier: GPL-3.0-only
+    See LICENSES/README.md for more information.
+"""
+
+import re
+from .record import PROBLEM, Record
+from .report import Report
+
+
+def version_is_valid(version):
+    """Checks if a version is valid
+
+    Args:
+        version (str): The version string
+
+    Returns:
+        [bool]: If the version is valid
+    """
+    return bool(re.match(r"^(\d+\.\d+(\.\d+){0,4}([+~\w]+(\.\d+)?)?)$",
+                    version))
+
+
+def check_version(report: Report, parsed_xml):
+    """Checks if the version for the addon defined in addon.xml is valid
+
+    Args:
+        report (Report): The report object
+        parsed_xml (et.Element): The parsed addon.xml
+    """
+    if "version" not in parsed_xml.attrib.keys():
+        report.add(Record(PROBLEM, "Missing version in addon.xml"))
+        return
+
+    if not version_is_valid(parsed_xml.attrib["version"]):
+        report.add(Record(PROBLEM, "Invalid version {} in addon.xml. " \
+            "Please use the major.minor.revision (e.g. 1.0.0) format or " \
+            "major.minor.revision+localversion_identifier (e.g. 1.0.0+matrix.1)".format(
+                parsed_xml.attrib["version"]
+            )))

--- a/tests/test_allowed_versions.py
+++ b/tests/test_allowed_versions.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+
+from kodi_addon_checker.check_allowed_versions import version_is_valid
+
+def test_addonversion_simple():
+    assert version_is_valid("1.0.1")
+
+
+def test_addonversion_localversionidentifier():
+    assert version_is_valid("1.0.1+matrix.1")
+
+
+def test_addonversion_localversionidentifier2():
+    assert version_is_valid("1.0.1+matrix.2")
+
+
+def test_invalidversion():
+    assert not version_is_valid("someinvalidversion")
+
+
+def test_invalidbackportversion():
+    assert not version_is_valid("2.3.0-backported-Leia")


### PR DESCRIPTION
Follow up to https://github.com/xbmc/repository-generator/pull/16, this makes addon-checker validate the provided version in addon.xml against the regex used in repository-generator. This makes sure the checker catches any invalid version in advance