### PR TITLE
Remove usage of packaging.LegacyVersion (removed in py3.11)

### DIFF
--- a/kodi_addon_checker/versions.py
+++ b/kodi_addon_checker/versions.py
@@ -6,7 +6,7 @@
     See LICENSES/README.md for more information.
 """
 
-from packaging.version import parse, Version, LegacyVersion
+from packaging.version import parse, Version
 from kodi_addon_checker import ValidKodiVersions
 
 
@@ -20,8 +20,7 @@ class AddonVersion():
 
     @property
     def _islegacy_devversion(self):
-        return isinstance(self.version, LegacyVersion) and \
-            ("~beta" or "~alpha" in self.version)
+        return "~beta" or "~alpha" in self.version
 
     def __lt__(self, other):
         if not isinstance(other, self.__class__):


### PR DESCRIPTION
Drop the usage of `LegacyVersion`: ttps://github.com/pypa/packaging/pull/407