### PR TITLE
Build, test and lint using github actions

### DIFF
--- a/.github/workflows/test_and_lint_matrix.yml
+++ b/.github/workflows/test_and_lint_matrix.yml
@@ -1,0 +1,39 @@
+name: Build and test addon-checker
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+          pip install pylint
+          pip install pytest
+
+      - name: Run pytest
+        run: |
+          pytest -v;
+
+      - name: Run pylint
+        continue-on-error: true
+        run: |
+          pylint *


### PR DESCRIPTION
We cannot use travis anymore, so start migrating our old CI to github actions. It's important pytest is able to run against any open pull request to avoid regressions.