### PR TITLE
Add option `skip-dependency-checks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,5 @@ You can use the tool with the following options:
 --allow-folder-id-mismatch  allow the addon's folder name and id to mismatch
 --reporter                  enable a reporter, this option can be used multiple times
 --enable-debug-log          enable debug logging to kodi-addon-checker.log
+--skip-dependency-checks    do not check if addon dependencies are available in the official Kodi addon repository
 ```

--- a/kodi_addon_checker/__main__.py
+++ b/kodi_addon_checker/__main__.py
@@ -77,6 +77,8 @@ def main():
                         action="store_true")
     parser.add_argument("--enable-debug-log", help="Enable debug logging to kodi-addon-checker.log",
                         action="store_true", default=False)
+    parser.add_argument("--skip-dependency-checks", help="Do not check if addon dependencies are available \
+                        in the official Kodi addon repository", action="store_true", default=False)
     ConfigManager.fill_cmd_args(parser)
     args = parser.parse_args()
 

--- a/kodi_addon_checker/check_addon.py
+++ b/kodi_addon_checker/check_addon.py
@@ -65,7 +65,8 @@ def start(addon_path, args, all_repo_addons, config=None):
 
             check_url.check_url(addon_report, parsed_xml)
 
-            check_dependencies.check_addon_dependencies(addon_report, repo_addons, parsed_xml, args)
+            if not args.skip_dependency_checks:
+                check_dependencies.check_addon_dependencies(addon_report, repo_addons, parsed_xml, args)
 
             check_dependencies.check_reverse_dependencies(addon_report, addon_id, args.branch, all_repo_addons)
 


### PR DESCRIPTION
Adds an option to ignore dependency checks.
The reason for this is outlined in #263.
Closes #263.