### PR TITLE
Adds support for font addons 

### DIFF
--- a/kodi_addon_checker/schema_validation.py
+++ b/kodi_addon_checker/schema_validation.py
@@ -62,6 +62,7 @@ def _validation_checks(report: Report, parsed_xml, branch_name):
         'kodi.resource.language': 'language.xsd',
         'kodi.addon.metadata': 'metadata.xsd',
         'kodi.resource.uisounds': 'uisounds.xsd',
+        'kodi.resource.font': 'font.xsd',
         'kodi.vfs': 'binary_vfs.xsd',
         'xbmc.addon.metadata': 'metadata.xsd',
         'xbmc.addon.repository': 'repository.xsd',

--- a/kodi_addon_checker/xml_schema/gotham_images.xsd
+++ b/kodi_addon_checker/xml_schema/gotham_images.xsd
@@ -4,7 +4,6 @@
   <xs:element name="extension">
     <xs:complexType>
       <xs:attribute name="point" type="simpleIdentifier" use="required"/>
-      <xs:attribute name="compile" type="xs:boolean"/>
       <xs:attribute name="type" type="xs:string"/>
     </xs:complexType>
   </xs:element>

--- a/kodi_addon_checker/xml_schema/leia_font.xsd
+++ b/kodi_addon_checker/xml_schema/leia_font.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="extension">
+    <xs:complexType>
+      <xs:attribute name="point" type="simpleIdentifier" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="simpleIdentifier">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="kodi\.resource\.font"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
See https://github.com/xbmc/repo-resources/pull/392 . Font addons were added in Leia by @notspiff (see https://github.com/xbmc/xbmc/pull/12130)

Also drops the "compile" arg support for image addons, this is not supported in the code.